### PR TITLE
Say where liqui came from, add a components directory, and fix registry cross-references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,17 @@ ships.
 3. Register both in `apps/www/registry.json`. The `ui` item needs `dependencies`,
    `registryDependencies` and a `target`; the example needs `registryDependencies`
    pointing at the component.
+
+   **Reference liqui's own items by full URL**, as the existing items do
+   (`"https://liqui.design/r/liqui.json"`, not `"liqui"`). The shadcn CLI resolves a
+   bare name against `ui.shadcn.com`, so `"button"` silently installs *shadcn's*
+   button instead of ours. `"utils"` is the deliberate exception — shadcn's `cn` is
+   byte-for-byte ours, and sharing it dedupes with whatever the consumer already has.
+
+   Every `ui` item must depend on the `liqui` style item, because that is what writes
+   the `--lq-*` tokens into the consumer's `globals.css`. Component sources read those
+   tokens without fallbacks: omit it and `variant="accent"` renders as plain glass with
+   no error anywhere.
 4. Write `apps/www/content/docs/components/<name>.mdx` and add it to
    `content/docs/components/meta.json`. Render demos with
    `<ComponentPreview name="<name>-demo" />`.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Surfaces that actually refract what is behind them — a canvas-generated displacement
 map driving an SVG filter, not a blur with a white overlay.
 
-[Documentation](https://liqui.design) · [Glass handbook](https://liqui.design/docs/handbook/glass) · [Components](https://liqui.design/docs/components/button)
+[Documentation](https://liqui.design) · [Glass handbook](https://liqui.design/docs/handbook/glass) · [Components](https://liqui.design/docs/components/button) · [Gallery](https://liquidglassdesign.com/?ref=liqui.design)
 
 [![npm](https://img.shields.io/npm/v/@liqui-design/glass?color=%232f6bff&label=%40liqui-design%2Fglass)](https://www.npmjs.com/package/@liqui-design/glass)
 [![license](https://img.shields.io/badge/license-MIT-blue)](./LICENSE)
@@ -19,6 +19,14 @@ map driving an SVG filter, not a blur with a white overlay.
 </div>
 
 ---
+
+## Where it came from
+
+liqui grew out of [Liquid Glass Design](https://liquidglassdesign.com/?ref=liqui.design),
+a curated gallery of liquid glass and glassmorphism references. Every one of them is a
+picture — enough to study the material, never enough to ship it, because the part that
+makes it glass is what the edge does to whatever is behind it, and that is not in a
+screenshot. The gallery keeps the references; this is the half you install.
 
 ## How it ships
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ because those are the parts you cannot reasonably maintain by hand.
 npx shadcn@latest add https://liqui.design/r/button.json
 ```
 
+That one command is the whole setup: it writes `components/ui/button.tsx`, adds the
+glass design tokens to your `globals.css`, and installs the kernel.
+
 Installing more than one? Register the namespace once in your `components.json`
 and drop the URLs:
 

--- a/apps/www/app/(home)/layout.tsx
+++ b/apps/www/app/(home)/layout.tsx
@@ -1,6 +1,40 @@
 import { HomeLayout } from 'fumadocs-ui/layouts/home';
 import { baseOptions } from '@/lib/layout.shared';
+import { appName, gallery } from '@/lib/shared';
 
 export default function Layout({ children }: LayoutProps<'/'>) {
-  return <HomeLayout {...baseOptions()}>{children}</HomeLayout>;
+  return (
+    <HomeLayout {...baseOptions()}>
+      {children}
+      <footer className="mt-auto border-t border-fd-border">
+        <div className="mx-auto flex w-full max-w-5xl flex-col gap-3 px-4 py-8 text-sm text-fd-muted-foreground sm:flex-row sm:items-center sm:justify-between">
+          <p>
+            {appName} — a{' '}
+            <a
+              href={gallery.url}
+              target="_blank"
+              rel="noreferrer"
+              className="underline decoration-fd-border underline-offset-4 transition hover:decoration-current"
+            >
+              {gallery.name}
+            </a>{' '}
+            project
+          </p>
+          <nav className="flex flex-wrap gap-x-5 gap-y-2">
+            <FooterLink href={gallery.url}>Gallery</FooterLink>
+            <FooterLink href={gallery.resources}>Resources</FooterLink>
+            <FooterLink href={gallery.guide}>Guide</FooterLink>
+          </nav>
+        </div>
+      </footer>
+    </HomeLayout>
+  );
+}
+
+function FooterLink({ href, children }: { href: string; children: React.ReactNode }) {
+  return (
+    <a href={href} target="_blank" rel="noreferrer" className="transition hover:text-fd-foreground">
+      {children}
+    </a>
+  );
 }

--- a/apps/www/app/(home)/page.tsx
+++ b/apps/www/app/(home)/page.tsx
@@ -1,7 +1,8 @@
 import Link from 'next/link';
+import { ArrowUpRight } from 'lucide-react';
 
 import { GlassStage } from '@/components/home/glass-stage';
-import { gitConfig } from '@/lib/shared';
+import { gallery, gitConfig } from '@/lib/shared';
 
 export default function HomePage() {
   return (
@@ -68,7 +69,44 @@ export default function HomePage() {
           automatically — no configuration, but do look at both.
         </Feature>
       </section>
+
+      <section className="mt-14 border-t border-fd-border pt-10 sm:mt-20 sm:grid sm:grid-cols-[auto_1fr] sm:gap-10">
+        <h2 className="mb-3 shrink-0 font-semibold sm:mb-0 sm:w-48">Where this came from</h2>
+        <div className="max-w-2xl">
+          <p className="text-fd-muted-foreground">
+            liqui started as a collection.{' '}
+            <strong className="font-medium text-fd-foreground">{gallery.name}</strong> gathers
+            liquid glass and glassmorphism references — interfaces, artwork, motion — and every one
+            of them is a picture. A picture is enough to study the material and not nearly enough to
+            ship it: you can copy the tint and the blur out of a screenshot, but the part that makes
+            it glass, the way an edge bends what is behind it, isn&apos;t in there to copy.
+          </p>
+          <p className="mt-3 text-fd-muted-foreground">
+            So the gallery kept the references and this became the other half of it — the same
+            material as components you install, in the browser, over your own background.
+          </p>
+          <div className="mt-5 flex flex-wrap gap-x-5 gap-y-2 text-sm font-medium">
+            <ExternalLink href={gallery.url}>Browse the gallery</ExternalLink>
+            <ExternalLink href={gallery.guide}>What liquid glass is</ExternalLink>
+            <ExternalLink href={gallery.devResources}>Developer resources</ExternalLink>
+          </div>
+        </div>
+      </section>
     </main>
+  );
+}
+
+function ExternalLink({ href, children }: { href: string; children: React.ReactNode }) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      className="inline-flex items-center gap-0.5 underline decoration-fd-border underline-offset-4 transition hover:decoration-current"
+    >
+      {children}
+      <ArrowUpRight className="size-3.5 opacity-60" />
+    </a>
   );
 }
 

--- a/apps/www/app/(home)/page.tsx
+++ b/apps/www/app/(home)/page.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 import { ArrowUpRight } from 'lucide-react';
 
 import { GlassStage } from '@/components/home/glass-stage';
-import { gallery, gitConfig } from '@/lib/shared';
+import { gallery } from '@/lib/shared';
 
 export default function HomePage() {
   return (
@@ -28,22 +28,12 @@ export default function HomePage() {
             Get started
           </Link>
           <Link
-            href="/docs/handbook/glass"
+            href="/docs/components"
             className="rounded-full border border-fd-border px-5 py-2 text-sm font-medium transition hover:bg-fd-muted"
           >
-            The material
+            View components
           </Link>
-          <a
-            href={`https://github.com/${gitConfig.user}/${gitConfig.repo}`}
-            className="rounded-full border border-fd-border px-5 py-2 text-sm font-medium transition hover:bg-fd-muted"
-          >
-            GitHub
-          </a>
         </div>
-
-        <code className="mt-6 inline-block rounded-lg bg-fd-muted px-3 py-1.5 text-sm">
-          npx shadcn@latest add https://liqui.design/r/button.json
-        </code>
       </section>
 
       <GlassStage />

--- a/apps/www/components/component-directory.tsx
+++ b/apps/www/components/component-directory.tsx
@@ -1,0 +1,105 @@
+import Link from 'next/link';
+
+import { ComponentPreview } from '@/components/component-preview';
+import { Index } from '@/registry/__index__';
+import { source } from '@/lib/source';
+import { docsRoute } from '@/lib/shared';
+
+const COMPONENTS_URL = `${docsRoute}/components`;
+
+/**
+ * Demos taller than a tile. Centring crops them at both ends, which for the
+ * accordion means opening on the middle of a sentence; from the top you get the
+ * first item's header, which is what the component looks like. Everything else
+ * fits, and centring is what makes a short demo sit properly in its tile.
+ */
+const CROP_FROM_TOP = new Set(['accordion-demo']);
+
+/**
+ * The components index, generated from the docs page tree rather than a hand-kept
+ * list — adding a component page and its meta.json entry is enough to make it
+ * appear here, in the same order the sidebar uses.
+ *
+ * Every tile shows the real demo on a real backdrop. A directory of a glass
+ * library that shows no glass is a directory of nothing: the whole claim is that
+ * these surfaces bend what is behind them, and a text link cannot make it.
+ *
+ * The demos are rendered but not operable. This page is navigation — a tile that
+ * swallows the click to toggle a switch is a tile that failed at its one job, and
+ * a half-working demo is worse than an honest picture. `inert` is what enforces
+ * it: pointer events, focus and the accessibility tree all stop at the preview,
+ * so each tile is a single tab stop that goes to the component's own page, where
+ * the demo is real. The link's `after` pseudo-element is what makes the whole
+ * tile clickable without nesting buttons and inputs inside an anchor.
+ */
+export function ComponentDirectory() {
+  const pages = source
+    .getPages()
+    .filter((page) => page.url.startsWith(`${COMPONENTS_URL}/`))
+    .sort((a, b) => order(a.url) - order(b.url));
+
+  return (
+    <div className="not-prose mt-8 grid gap-x-5 gap-y-6 sm:grid-cols-2">
+      {pages.map((page) => {
+        const slug = page.slugs[page.slugs.length - 1];
+        const demo = `${slug}-demo`;
+
+        return (
+          <div key={page.url} className="group relative">
+            {/* A fixed height, not a minimum: the demos are sized for a full
+                component page, and letting each one set its own leaves the grid
+                full of holes (the accordion alone is three times the switch).
+                Tiles are a uniform window onto the demo; the page behind the
+                link is where it gets to be its full size. */}
+            {demo in Index ? (
+              <div inert className="transition group-hover:brightness-110">
+                <ComponentPreview
+                  name={demo}
+                  hideCode
+                  align={CROP_FROM_TOP.has(demo) ? 'start' : 'center'}
+                  className="my-0 h-[220px] min-h-0 overflow-hidden p-5"
+                />
+              </div>
+            ) : null}
+            <h3 className="mt-3 text-sm font-medium">
+              <Link
+                href={page.url}
+                // Stretches over the whole tile, so the picture is part of the
+                // link target without being inside the anchor element.
+                className="after:absolute after:inset-0 after:rounded-xl group-hover:underline underline-offset-4"
+              >
+                {page.data.title}
+              </Link>
+            </h3>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * `getPages()` returns pages in no meaningful order, so the sidebar's own order —
+ * the one meta.json defines — is recovered from the page tree.
+ */
+function order(url: string): number {
+  const index = sidebarOrder().indexOf(url);
+  return index === -1 ? Number.MAX_SAFE_INTEGER : index;
+}
+
+let cached: string[] | undefined;
+function sidebarOrder(): string[] {
+  if (cached) return cached;
+
+  const urls: string[] = [];
+  const walk = (nodes: { type: string; url?: string; children?: unknown[] }[]) => {
+    for (const node of nodes) {
+      if (node.type === 'page' && node.url?.startsWith(`${COMPONENTS_URL}/`)) urls.push(node.url);
+      if (node.children) walk(node.children as typeof nodes);
+    }
+  };
+  walk(source.getPageTree().children as Parameters<typeof walk>[0]);
+
+  cached = urls;
+  return urls;
+}

--- a/apps/www/components/mdx.tsx
+++ b/apps/www/components/mdx.tsx
@@ -4,6 +4,7 @@ import { TypeTable } from 'fumadocs-ui/components/type-table';
 import type { MDXComponents } from 'mdx/types';
 
 import { ComponentPreview } from '@/components/component-preview';
+import { ComponentDirectory } from '@/components/component-directory';
 
 export function getMDXComponents(components?: MDXComponents) {
   return {
@@ -11,6 +12,7 @@ export function getMDXComponents(components?: MDXComponents) {
     // Available in every page without an import — a component doc that has to
     // import its own preview harness on line 1 invites drift.
     ComponentPreview,
+    ComponentDirectory,
     Tabs,
     Tab,
     TypeTable,

--- a/apps/www/content/docs/components/button.mdx
+++ b/apps/www/content/docs/components/button.mdx
@@ -11,10 +11,10 @@ description: A button rendered as a refracting glass surface, with accent and da
 npx shadcn@latest add https://liqui.design/r/button.json
 ```
 
-This writes `components/ui/button.tsx` into your project and installs
-`@liqui-design/glass` — the refraction kernel, which stays a dependency because it is
-not something you should be editing. Everything you *would* want to edit is in
-the file you just received.
+This writes `components/ui/button.tsx` into your project, adds the glass design
+tokens to your `globals.css`, and installs `@liqui-design/glass` — the refraction
+kernel, which stays a dependency because it is not something you should be
+editing. Everything you *would* want to edit is in the file you just received.
 
 Installing more than one? Register the namespace once in `components.json` and
 drop the URLs:

--- a/apps/www/content/docs/components/index.mdx
+++ b/apps/www/content/docs/components/index.mdx
@@ -1,0 +1,28 @@
+---
+title: Components
+description: Every liqui component, shown on a real backdrop.
+---
+
+Nine components so far, each a `LiquiGlass` surface with a Base UI primitive
+driving it. Every tile below is the real component rendering the real material —
+open one to try it, read what is specific about putting it on glass, and copy the
+source `shadcn add` writes into your project.
+
+<Callout type="info">
+  Refraction renders in Chromium. In Safari and Firefox these tiles fall back to
+  frosted blur automatically, which is worth seeing too — see
+  [Glass](/docs/handbook/glass#degradation).
+</Callout>
+
+<ComponentDirectory />
+
+## Installing
+
+Any one of them is a single command, and the first one you add brings the glass
+design tokens with it:
+
+```bash
+npx shadcn@latest add https://liqui.design/r/button.json
+```
+
+See [Quick start](/docs) for the namespace setup if you are adding several.

--- a/apps/www/content/docs/handbook/glass.mdx
+++ b/apps/www/content/docs/handbook/glass.mdx
@@ -103,3 +103,27 @@ sizes and immune to transforms.
 `feImage` SVG sources with CSS features disabled — `mix-blend-mode` and modern
 `hsl()` silently do nothing, corrupting the map into a full-surface smear.
 Generate it on a canvas.
+
+## Where to look next
+
+Tuning these dials is mostly a matter of having seen enough of the material.
+liqui grew out of [Liquid Glass Design](https://liquidglassdesign.com/?ref=liqui.design),
+a growing gallery of liquid glass and glassmorphism references — interfaces,
+artwork and motion, each with the style prompt used to recreate it. It is the
+fastest way to work out what you are actually aiming at before you start moving
+`frost` and `refraction` around.
+
+<Cards>
+  <Card
+    title="Gallery"
+    href="https://liquidglassdesign.com/?ref=liqui.design"
+    external
+    description="Curated liquid glass references, by UI, art and video."
+  />
+  <Card
+    title="What liquid glass is"
+    href="https://liquidglassdesign.com/what-is-liquid-glass?ref=liqui.design"
+    external
+    description="The material as Apple defines it, and how it differs from glassmorphism."
+  />
+</Cards>

--- a/apps/www/content/docs/index.mdx
+++ b/apps/www/content/docs/index.mdx
@@ -7,6 +7,10 @@ liqui is a set of liquid-glass components built on [Base UI](https://base-ui.com
 primitives. Components arrive as **source code in your project** through the
 shadcn CLI; only the refraction kernel stays a dependency.
 
+It comes out of [Liquid Glass Design](https://liquidglassdesign.com/?ref=liqui.design),
+a gallery of liquid glass references — this is the part of that collection you
+can install.
+
 ## Install
 
 Adding a component is the whole setup:

--- a/apps/www/content/docs/index.mdx
+++ b/apps/www/content/docs/index.mdx
@@ -89,5 +89,5 @@ how it looks.
 
 <Cards>
   <Card title="Glass" href="/docs/handbook/glass" description="The material, its dials, and where it degrades." />
-  <Card title="Button" href="/docs/components/button" description="The first component." />
+  <Card title="Components" href="/docs/components" description="All nine, shown on a real backdrop." />
 </Cards>

--- a/apps/www/content/docs/index.mdx
+++ b/apps/www/content/docs/index.mdx
@@ -9,7 +9,21 @@ shadcn CLI; only the refraction kernel stays a dependency.
 
 ## Install
 
-Register the namespace once:
+Adding a component is the whole setup:
+
+```bash
+npx shadcn@latest add https://liqui.design/r/button.json
+```
+
+That writes `components/ui/button.tsx` into your project, adds the glass design
+tokens to your `globals.css`, and installs
+[`@liqui-design/glass`](https://www.npmjs.com/package/@liqui-design/glass) — the SVG
+filter registry, displacement-map generator and browser fallbacks. That package
+is the one part of liqui you are not meant to edit; everything else lands in
+your repo as plain TSX.
+
+Installing more than one? Register the namespace once in `components.json` and
+drop the URLs:
 
 ```json title="components.json"
 {
@@ -19,18 +33,9 @@ Register the namespace once:
 }
 ```
 
-Then set up the theme and add whatever you need:
-
 ```bash
-npx shadcn@latest add @liqui-design/liqui
-npx shadcn@latest add @liqui-design/button
+npx shadcn@latest add @liqui-design/button @liqui-design/select
 ```
-
-`@liqui-design/liqui` writes the glass design tokens into your `globals.css` and pulls
-in [`@liqui-design/glass`](https://www.npmjs.com/package/@liqui-design/glass) — the SVG filter
-registry, displacement-map generator and browser fallbacks. That package is the
-one part of liqui you are not meant to edit; everything else lands in your repo
-as plain TSX.
 
 <Callout type="warn">
   `@liqui-design/button` is a **registry** item, not an npm package —
@@ -40,11 +45,11 @@ as plain TSX.
   `@liqui-design/glass`, and the CLI installs it for you.
 </Callout>
 
-Prefer not to configure anything? Every component page also gives a direct URL
-that needs no namespace:
+Building your own surfaces on top of `LiquiGlass` instead? The theme is
+installable on its own — it is what every component above pulls in:
 
 ```bash
-npx shadcn@latest add https://liqui.design/r/button.json
+npx shadcn@latest add https://liqui.design/r/liqui.json
 ```
 
 <Callout type="info">

--- a/apps/www/e2e/visual.spec.ts
+++ b/apps/www/e2e/visual.spec.ts
@@ -109,6 +109,9 @@ test.describe('no console errors', () => {
   for (const path of [
     '/',
     '/docs',
+    // The directory mounts every demo at once — the one page where a component
+    // that misbehaves off its own page has somewhere to show up.
+    '/docs/components',
     '/docs/components/alert-dialog',
     '/docs/components/select',
     '/docs/handbook/glass',

--- a/apps/www/lib/layout.shared.tsx
+++ b/apps/www/lib/layout.shared.tsx
@@ -1,5 +1,7 @@
 import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared';
-import { appName, gitConfig } from './shared';
+import { ArrowUpRight } from 'lucide-react';
+
+import { appName, docsRoute, gallery, gitConfig } from './shared';
 
 export function baseOptions(): BaseLayoutProps {
   return {
@@ -7,6 +9,21 @@ export function baseOptions(): BaseLayoutProps {
       // JSX supported
       title: appName,
     },
+    links: [
+      { text: 'Docs', url: docsRoute, active: 'nested-url' },
+      {
+        // Off-site on purpose: the gallery is where the look is collected,
+        // this site is where it becomes code. The arrow marks the hop.
+        text: (
+          <>
+            Gallery
+            <ArrowUpRight className="size-3.5 opacity-60" />
+          </>
+        ),
+        url: gallery.url,
+        external: true,
+      },
+    ],
     githubUrl: `https://github.com/${gitConfig.user}/${gitConfig.repo}`,
   };
 }

--- a/apps/www/lib/shared.ts
+++ b/apps/www/lib/shared.ts
@@ -10,6 +10,37 @@ export const gitConfig = {
 };
 
 /**
+ * Every outbound link to the gallery carries `ref` so the traffic the docs send
+ * over is attributable on the other side. Built here rather than written into
+ * the copy, because a hand-written URL is exactly where the parameter goes
+ * missing — and where `?cat=dev&ref=` turns into a second `?`.
+ */
+function galleryUrl(path: string, query?: Record<string, string>): string {
+  const url = new URL(path, 'https://liquidglassdesign.com');
+  for (const [key, value] of Object.entries(query ?? {})) url.searchParams.set(key, value);
+  url.searchParams.set('ref', 'liqui.design');
+  return url.toString();
+}
+
+/**
+ * liqui came out of Liquid Glass Design, the gallery of liquid-glass work the
+ * same author curates. The two sites stay separate and cross-link: the gallery
+ * is where the look is collected, liqui is where it becomes installable code.
+ * Kept here so the copy on the home page, the footer and the docs all point at
+ * the same URLs.
+ *
+ * Deliberately no reference count: the gallery grows, and a number baked into
+ * this site is a number that is wrong a month from now.
+ */
+export const gallery = {
+  name: 'Liquid Glass Design',
+  url: galleryUrl('/'),
+  resources: galleryUrl('/resources'),
+  devResources: galleryUrl('/resources', { cat: 'dev' }),
+  guide: galleryUrl('/what-is-liquid-glass'),
+};
+
+/**
  * Where the built registry is served from. Users either hit these URLs directly
  * or register `"@liqui": "<siteUrl>/r/{name}.json"` in their components.json.
  */

--- a/apps/www/registry.json
+++ b/apps/www/registry.json
@@ -64,7 +64,7 @@
       "title": "Glass Button",
       "description": "A button rendered as a refracting glass surface, with accent and danger tints.",
       "dependencies": ["@base-ui/react", "@liqui-design/glass", "class-variance-authority"],
-      "registryDependencies": ["utils"],
+      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
       "files": [
         {
           "path": "registry/liqui/ui/button.tsx",
@@ -79,7 +79,7 @@
       "title": "Glass Checkbox",
       "description": "A checkbox whose glass fills with accent when checked, keeping the bezel and rim light.",
       "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["utils"],
+      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
       "files": [
         { "path": "registry/liqui/ui/checkbox.tsx", "type": "registry:ui", "target": "@ui/checkbox.tsx" }
       ]
@@ -90,7 +90,7 @@
       "title": "Glass Field",
       "description": "A labelled form field whose control sits on its own glass surface.",
       "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["utils"],
+      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
       "files": [
         { "path": "registry/liqui/ui/field.tsx", "type": "registry:ui", "target": "@ui/field.tsx" }
       ]
@@ -101,7 +101,7 @@
       "title": "Glass Accordion",
       "description": "Collapsible panels where each item is its own resizing glass surface.",
       "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["utils"],
+      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
       "files": [
         { "path": "registry/liqui/ui/accordion.tsx", "type": "registry:ui", "target": "@ui/accordion.tsx" }
       ]
@@ -112,7 +112,7 @@
       "title": "Glass Alert Dialog",
       "description": "A modal confirmation dialog on the library's largest glass surface.",
       "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["utils"],
+      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
       "files": [
         { "path": "registry/liqui/ui/alert-dialog.tsx", "type": "registry:ui", "target": "@ui/alert-dialog.tsx" }
       ]
@@ -123,7 +123,7 @@
       "title": "Glass Context Menu",
       "description": "A right-click menu with submenus, checkbox and radio items, on a keep-mounted glass popup.",
       "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["utils"],
+      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
       "files": [
         { "path": "registry/liqui/ui/context-menu.tsx", "type": "registry:ui", "target": "@ui/context-menu.tsx" }
       ]
@@ -134,7 +134,7 @@
       "title": "Glass Switch",
       "description": "A switch whose glass track retints with accent, carrying an opaque thumb.",
       "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["utils"],
+      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
       "files": [
         { "path": "registry/liqui/ui/switch.tsx", "type": "registry:ui", "target": "@ui/switch.tsx" }
       ]
@@ -145,7 +145,7 @@
       "title": "Glass Slider",
       "description": "A slider whose thumb is the refracting surface, sliding along a flat rail.",
       "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["utils"],
+      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
       "files": [
         { "path": "registry/liqui/ui/slider.tsx", "type": "registry:ui", "target": "@ui/slider.tsx" }
       ]
@@ -156,7 +156,7 @@
       "title": "Glass Select",
       "description": "A select with a glass trigger and a glass popup, kept from overlapping each other.",
       "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["utils"],
+      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
       "files": [
         { "path": "registry/liqui/ui/select.tsx", "type": "registry:ui", "target": "@ui/select.tsx" }
       ]
@@ -166,7 +166,7 @@
       "type": "registry:example",
       "title": "Button",
       "description": "A single glass button.",
-      "registryDependencies": ["button"],
+      "registryDependencies": ["https://liqui.design/r/button.json"],
       "files": [{ "path": "registry/liqui/examples/button-demo.tsx", "type": "registry:example" }]
     },
     {
@@ -174,7 +174,7 @@
       "type": "registry:example",
       "title": "Variants",
       "description": "Variants retint the glass instead of painting over it.",
-      "registryDependencies": ["button"],
+      "registryDependencies": ["https://liqui.design/r/button.json"],
       "files": [
         { "path": "registry/liqui/examples/button-variants.tsx", "type": "registry:example" }
       ]
@@ -184,7 +184,7 @@
       "type": "registry:example",
       "title": "Tuning the glass",
       "description": "The glass prop reaches the surface underneath the button.",
-      "registryDependencies": ["button"],
+      "registryDependencies": ["https://liqui.design/r/button.json"],
       "files": [
         { "path": "registry/liqui/examples/button-glass-dial.tsx", "type": "registry:example" }
       ]
@@ -194,7 +194,7 @@
       "type": "registry:example",
       "title": "Disabled",
       "description": "Disabled buttons drop the hover wash and dim the whole surface.",
-      "registryDependencies": ["button"],
+      "registryDependencies": ["https://liqui.design/r/button.json"],
       "files": [
         { "path": "registry/liqui/examples/button-disabled.tsx", "type": "registry:example" }
       ]
@@ -204,7 +204,7 @@
       "type": "registry:example",
       "title": "Checkbox",
       "description": "Checked, unchecked, indeterminate and disabled.",
-      "registryDependencies": ["checkbox"],
+      "registryDependencies": ["https://liqui.design/r/checkbox.json"],
       "files": [{ "path": "registry/liqui/examples/checkbox-demo.tsx", "type": "registry:example" }]
     },
     {
@@ -212,7 +212,7 @@
       "type": "registry:example",
       "title": "Field",
       "description": "Label, control and description.",
-      "registryDependencies": ["field"],
+      "registryDependencies": ["https://liqui.design/r/field.json"],
       "files": [{ "path": "registry/liqui/examples/field-demo.tsx", "type": "registry:example" }]
     },
     {
@@ -220,7 +220,7 @@
       "type": "registry:example",
       "title": "Validation",
       "description": "The invalid ring lives on the surface, not the input.",
-      "registryDependencies": ["field"],
+      "registryDependencies": ["https://liqui.design/r/field.json"],
       "files": [
         { "path": "registry/liqui/examples/field-validation.tsx", "type": "registry:example" }
       ]
@@ -230,7 +230,7 @@
       "type": "registry:example",
       "title": "Accordion",
       "description": "Each item is its own glass surface, resizing with its panel.",
-      "registryDependencies": ["accordion"],
+      "registryDependencies": ["https://liqui.design/r/accordion.json"],
       "files": [
         { "path": "registry/liqui/examples/accordion-demo.tsx", "type": "registry:example" }
       ]
@@ -240,7 +240,7 @@
       "type": "registry:example",
       "title": "Alert Dialog",
       "description": "A destructive confirmation over a dimmed scrim.",
-      "registryDependencies": ["alert-dialog", "button"],
+      "registryDependencies": ["https://liqui.design/r/alert-dialog.json", "https://liqui.design/r/button.json"],
       "files": [
         { "path": "registry/liqui/examples/alert-dialog-demo.tsx", "type": "registry:example" }
       ]
@@ -250,7 +250,7 @@
       "type": "registry:example",
       "title": "Context Menu",
       "description": "Submenus, checkbox and radio items, shortcuts and a destructive action.",
-      "registryDependencies": ["context-menu"],
+      "registryDependencies": ["https://liqui.design/r/context-menu.json"],
       "files": [
         { "path": "registry/liqui/examples/context-menu-demo.tsx", "type": "registry:example" }
       ]
@@ -260,7 +260,7 @@
       "type": "registry:example",
       "title": "Switch",
       "description": "A settings list: on, off and disabled.",
-      "registryDependencies": ["switch"],
+      "registryDependencies": ["https://liqui.design/r/switch.json"],
       "files": [{ "path": "registry/liqui/examples/switch-demo.tsx", "type": "registry:example" }]
     },
     {
@@ -268,7 +268,7 @@
       "type": "registry:example",
       "title": "Slider",
       "description": "A glass thumb travelling along a flat rail.",
-      "registryDependencies": ["slider"],
+      "registryDependencies": ["https://liqui.design/r/slider.json"],
       "files": [{ "path": "registry/liqui/examples/slider-demo.tsx", "type": "registry:example" }]
     },
     {
@@ -276,7 +276,7 @@
       "type": "registry:example",
       "title": "Range",
       "description": "Two thumbs on one rail, sharing a single cached map.",
-      "registryDependencies": ["slider"],
+      "registryDependencies": ["https://liqui.design/r/slider.json"],
       "files": [{ "path": "registry/liqui/examples/slider-range.tsx", "type": "registry:example" }]
     },
     {
@@ -284,7 +284,7 @@
       "type": "registry:example",
       "title": "Select",
       "description": "Grouped options on a glass popup below the trigger.",
-      "registryDependencies": ["select"],
+      "registryDependencies": ["https://liqui.design/r/select.json"],
       "files": [{ "path": "registry/liqui/examples/select-demo.tsx", "type": "registry:example" }]
     }
   ]


### PR DESCRIPTION
Four commits, one of which is a real bug.

## fix(registry): reference liqui's own items by URL, not by bare name

The shadcn CLI resolves a bare `registryDependencies` name against **ui.shadcn.com**, not against the registry the item was fetched from. Every cross-reference here was pointing at the wrong place:

- No `ui` item depended on the `liqui` style item, so `shadcn add .../r/button.json` installed `button.tsx` **without the `--lq-*` tokens it reads**. They are declared only in the style item's `cssVars`, and the component source has no fallbacks — so `variant="accent"` came out as plain glass, silently. Adding `"liqui"` does not fix it; the CLI errors with `The item at ui.shadcn.com/r/styles/new-york-v4/liqui.json was not found`.
- Every example depended on `"button"`, `"select"` and friends, which resolve to *shadcn's* components. Installing `alert-dialog-demo` got you shadcn's button next to liqui's dialog.

Verified against the real CLI (`shadcn add --dry-run` into a scratch project, registry served locally):

| | before | after |
| --- | --- | --- |
| `add .../r/button.json` | 2 files, 0 CSS vars | 2 files, **23 CSS vars** |
| `add @liqui-design/button` | 2 files, 0 CSS vars | 2 files, **23 CSS vars** |
| `add .../r/alert-dialog-demo.json` | shadcn's button | 4 files, all liqui's (`--view` confirms `LiquiGlass`) |

`utils` deliberately stays a bare name — shadcn's `cn` is byte-for-byte ours, and sharing the item dedupes with whatever the consumer already has. The convention and the reasoning are now in CONTRIBUTING, at the step where the next component would reintroduce it.

## feat(www): say where liqui came from

liqui is the component half of [liquidglassdesign.com](https://liquidglassdesign.com), and nothing on the site said so. Framed as an origin story rather than a "sub-project" label: the gallery collects the references, and every one of them is a picture — enough to study the material, never enough to ship it. Adds a home-page section, a Gallery nav link (alongside Docs, which the nav was also missing), a footer, and handbook cross-links. Outbound links carry `ref` for attribution, built in `lib/shared.ts` so the parameter cannot go missing. No reference count anywhere — the gallery grows.

## feat(www): add a components directory

`/docs/components` had no page of its own. Now it is a grid of live tiles, generated from the docs page tree so adding a component page is enough to make it appear.

The demos render but are **not operable** — the page is navigation. `inert` stops pointer events, focus and the accessibility tree at the preview, so each tile is a single tab stop leading to the component's page. The title link's `after` pseudo-element stretches over the tile, making the picture part of the link target without nesting buttons and inputs inside an anchor. Verified: clicking a switch control inside a tile navigates instead of toggling; Tab reaches exactly 9 tile links; the 25 focusable elements inside previews are all unreachable.

## refactor(www): trim the hero to two calls to action

Get started and View components. The handbook is one click further into the docs, GitHub is already a nav icon, and the install command was the escape-hatch form — which, until the registry fix above, did not even install the tokens.

---

**Checks:** `pnpm typecheck` and `pnpm build` pass; the visual suite is 21/21 with **no baseline changes** — the hero rework nets out to the same stage geometry, so the Linux baselines stay valid. No changeset: `packages/glass` is untouched.

**Note:** `apps/www/AGENTS.md` and `CLAUDE.md` are generated by `next dev` and left untracked here — worth either committing or gitignoring, but that is your call, not this PR's.