### PR TITLE
chore: ignore the agent rule files next dev generates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,11 @@ apps/www/registry/__sources__.ts
 .claude/
 .cursor/
 
+# `next dev` writes its own agent rules into the app directory on every run and
+# re-creates them if deleted, so tracking these only produces churn in diffs.
+apps/*/AGENTS.md
+apps/*/CLAUDE.md
+
 # Playwright
 apps/www/test-results
 apps/www/playwright-report


### PR DESCRIPTION
`next dev` writes a `nextjs-agent-rules` block into `AGENTS.md` and `CLAUDE.md` in the app directory on every run, and re-creates them if deleted. Tracking them would mean a tool-generated file turning up in unrelated diffs.

Scoped to `apps/*` so a hand-written `AGENTS.md` at the repo root stays trackable.