### PR TITLE
feat(www): measure traffic with google analytics

### DIFF
--- a/apps/www/app/layout.tsx
+++ b/apps/www/app/layout.tsx
@@ -2,8 +2,9 @@ import type { Metadata } from 'next';
 import { RootProvider } from 'fumadocs-ui/provider/next';
 import './global.css';
 import { Inter } from 'next/font/google';
+import { GoogleAnalytics } from '@next/third-parties/google';
 
-import { appName, siteUrl } from '@/lib/shared';
+import { appName, googleAnalyticsId, siteUrl } from '@/lib/shared';
 
 const inter = Inter({
   subsets: ['latin'],
@@ -29,6 +30,13 @@ export default function Layout({ children }: LayoutProps<'/'>) {
       <body className="flex flex-col min-h-screen">
         <RootProvider>{children}</RootProvider>
       </body>
+      {/*
+        Only in a production build: `next dev` would otherwise report every
+        local page view into the same property, and localhost traffic is not
+        traffic. The component loads gtag.js after hydration, so it costs
+        nothing on first paint.
+      */}
+      {process.env.NODE_ENV === 'production' && <GoogleAnalytics gaId={googleAnalyticsId} />}
     </html>
   );
 }

--- a/apps/www/lib/shared.ts
+++ b/apps/www/lib/shared.ts
@@ -3,6 +3,12 @@ export const docsRoute = '/docs';
 export const docsImageRoute = '/og/docs';
 export const docsContentRoute = '/llms.mdx/docs';
 
+/**
+ * GA4 measurement ID. Public by design — it ships in the page source of every
+ * site that uses it, so there is nothing gained by moving it into an env var.
+ */
+export const googleAnalyticsId = 'G-WD95MFJ6ZJ';
+
 export const gitConfig = {
   user: 'leefanv',
   repo: 'liqui-design',

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@base-ui/react": "^1.6.0",
     "@liqui-design/glass": "workspace:*",
+    "@next/third-parties": "^16.3.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "fumadocs-core": "^16.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       '@liqui-design/glass':
         specifier: workspace:*
         version: link:../../packages/glass
+      '@next/third-parties':
+        specifier: ^16.3.0
+        version: 16.3.0(next@16.3.0(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -919,6 +922,12 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@next/third-parties@16.3.0':
+    resolution: {integrity: sha512-cAA96hSI9NC7083b6sEsKjgyvM/YJ2eqXs4HWv8a/z5LE12CL1sUJS+cmcTwNMY4yAFpLyyuZHrMBEfh/4Xupw==}
+    peerDependencies:
+      next: ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -3991,6 +4000,9 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  third-party-capital@1.0.20:
+    resolution: {integrity: sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==}
+
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
@@ -5113,6 +5125,12 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@16.3.0':
     optional: true
+
+  '@next/third-parties@16.3.0(next@16.3.0(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      next: 16.3.0(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react: 19.2.8
+      third-party-capital: 1.0.20
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -8365,6 +8383,8 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  third-party-capital@1.0.20: {}
 
   tiny-invariant@1.3.3: {}
 


### PR DESCRIPTION
Adds the GA4 tag (`G-WD95MFJ6ZJ`) to liqui.design.

Loaded through `@next/third-parties`'s `<GoogleAnalytics>` in the root layout rather than a hand-written script tag: gtag.js is deferred until after hydration, and client-side route changes are reported without extra wiring — which matters here, since everything past the landing page is a client-side navigation.

Gated on `NODE_ENV === 'production'` so `next dev` doesn't file local page views into the property. Preview deployments do report, since Vercel builds those as production too — happy to key it off the hostname instead if that noise isn't wanted.

The measurement ID sits in `lib/shared.ts` next to the other site constants rather than in an env var: it ships in the page source of every site that uses it, so there's nothing to hide.

## Verification

- `pnpm typecheck` and `pnpm build` pass at the root.
- `G-WD95MFJ6ZJ` appears in the prerendered HTML of the production build.
- Still to confirm after deploy: a hit in GA Realtime, and that *Enhanced Measurement → page changes based on browser history events* is enabled, without which only landing pages get counted.