### PR TITLE
ci: adopt the dev/main branch strategy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,6 +9,7 @@ catch problems which otherwise surface in someone else's project.
 
 ## Checklist
 
+- [ ] Base branch is `dev` (only a release PR targets `main`)
 - [ ] `pnpm typecheck` and `pnpm build` pass
 - [ ] Changed `packages/glass`? Added a changeset (`pnpm changeset`) and ran
       `pnpm --filter @liqui-design/glass test:package`

--- a/.github/workflows/branch-policy.yml
+++ b/.github/workflows/branch-policy.yml
@@ -1,0 +1,44 @@
+name: Branch policy
+
+# Runs on every pull request, including the ones into dev where it has nothing to
+# check. That is deliberate: a required status check has to be reported on every
+# PR, or the ones it never runs for sit at "Expected" and can't be merged at all.
+on:
+  pull_request:
+
+concurrency:
+  group: branch-policy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  base:
+    name: PR base
+    runs-on: ubuntu-latest
+    steps:
+      # The default branch is main, so that is what GitHub pre-fills as the base
+      # for a new PR, and feature work aimed at dev lands one dropdown away from
+      # going straight to production. Nothing else catches that: the diff looks
+      # right, CI passes, and it only shows up as a release nobody meant to cut.
+      - name: Check the base branch
+        env:
+          BASE: ${{ github.base_ref }}
+          HEAD: ${{ github.head_ref }}
+        run: |
+          if [ "$BASE" != 'main' ]; then
+            echo "Base is $BASE. Nothing to check."
+            exit 0
+          fi
+
+          # Only two heads may open a PR into main: dev, promoting what has
+          # already settled there, and the release branch changesets opens on its
+          # own. A hotfix is not an exception — it goes through dev like anything
+          # else, or the next dev -> main PR quietly reverts it.
+          case "$HEAD" in
+            dev | changeset-release/*)
+              echo "$HEAD -> main is allowed."
+              ;;
+            *)
+              echo "::error::'$HEAD' cannot open a pull request into main. Re-target this PR at dev: gh pr edit <number> --base dev"
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,7 +3,7 @@ name: Checks
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [main, dev]
 
 concurrency:
   group: checks-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,11 @@ name: CI
 
 on:
   pull_request:
+  # Both protected branches. `pull_request` already covers the way code gets in,
+  # so this is the after-the-merge run: it catches a semantic conflict between two
+  # PRs that each passed on their own.
   push:
-    branches: [main]
+    branches: [main, dev]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Release
 
 on:
+  # main only, deliberately. dev is where changes accumulate and a changeset can
+  # still be rewritten; main is the branch a version on npm is allowed to come
+  # from. Adding dev here would publish every merged feature.
   push:
     branches: [main]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,31 @@ cd liqui-design
 pnpm install
 ```
 
+## Branches
+
+```
+feature/*  ──PR──> dev ──PR──> main ──auto──> production
+hotfix/*   ──PR──> dev ──PR──> main ──auto──> production
+```
+
+`dev` and `main` are both protected and neither accepts a direct push. Everything
+arrives through a pull request, including anything you write yourself.
+
+- **`dev`** is where work lands. Branch from it, and open your PR back into it.
+  Name the branch `feature/<what>`, or `hotfix/<what>` if you are fixing something
+  that is already in production.
+- **`main`** is production. It only ever receives a PR from `dev`, and merging one
+  deploys the site and runs the release workflow.
+
+A hotfix takes the same route as a feature. It is a separate prefix so the branch
+list says which is which, not a shortcut past `dev` — skipping `dev` means the next
+`dev` → `main` PR silently reverts the fix.
+
+CI runs on every PR and again on `dev` and `main` after a merge, which is what
+catches two PRs that passed separately and conflict together. Releases run from
+`main` alone: merging to `main` opens a "Version Packages" PR, and merging *that*
+publishes to npm.
+
 ## Layout
 
 ```
@@ -145,6 +170,9 @@ and say *why* where it isn't obvious. Releases are automated: merging to `main` 
 "Version Packages" PR, and merging that publishes.
 
 ## Before opening a PR
+
+Open it against `dev`, not `main` — see [Branches](#branches). GitHub will offer
+`main` as the base, so this is the one thing worth checking twice.
 
 ```bash
 pnpm typecheck

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,15 @@ A hotfix takes the same route as a feature. It is a separate prefix so the branc
 list says which is which, not a shortcut past `dev` — skipping `dev` means the next
 `dev` → `main` PR silently reverts the fix.
 
+The default branch is `main`, so GitHub pre-fills `main` as the base for a new PR
+and feature work is one dropdown away from going straight to production. The
+**Branch policy** check fails any PR into `main` whose head is not `dev` or the
+release branch changesets opens. If you see it go red, re-target the PR:
+
+```bash
+gh pr edit <number> --base dev
+```
+
 CI runs on every PR and again on `dev` and `main` after a merge, which is what
 catches two PRs that passed separately and conflict together. Releases run from
 `main` alone: merging to `main` opens a "Version Packages" PR, and merging *that*


### PR DESCRIPTION
Sets up the two-branch model. First PR to go through it.

```
feature/* ──PR──> dev ──PR──> main ──auto──> production
hotfix/*  ──PR──> dev ──PR──> main ──auto──> production
```

### Already applied to the repo (settings, not code)

- `dev` branch created from `main`.
- **"Protected branches" ruleset** on `refs/heads/main` and `refs/heads/dev`: pull request required, force push blocked, deletion blocked, and `Build and typecheck` / `Package publishability` / `Page checks` required green.
- **No bypass actors** — it applies to the owner too, which is what "禁止直接 push" means.
- **Zero required approvals.** A single maintainer can't approve their own PR, so any other number locks the repo. The rule still forces every change through a PR with green CI.

### In this diff

- `ci.yml` and `checks.yml` also run on a push to `dev`. Every route in is a PR that already ran them, so this is the after-the-merge run that catches two PRs which passed separately and break together.
- `release.yml` deliberately stays on `main` only. `dev` is where changesets pile up and can still be rewritten; publishing from it would cut a version per merged feature.
- CONTRIBUTING gets a Branches section, and "Before opening a PR" now says to target `dev`.
- PR template gets a base-branch checkbox.

### Still open, needs your call

The GitHub **default branch is still `main`**, so GitHub offers `main` as the base for new PRs — the one footgun left in this setup. Switching the default to `dev` fixes it, but Vercel's production branch was seeded from the repo default, and I can't read that setting from here. Confirm Vercel is pinned to `main`, then flip it; doing it blind risks pointing production at `dev`.