### PR TITLE
chore(deps): upgrade Base UI to 1.7.0

### DIFF
--- a/.changeset/quiet-spoons-repeat.md
+++ b/.changeset/quiet-spoons-repeat.md
@@ -1,0 +1,20 @@
+---
+'@liqui-design/glass': patch
+---
+
+Give the forwarded ref a stable imperative handle.
+
+`useImperativeHandle` was called without a dependency array, so it re-ran on
+every render — detaching the previous handle and attaching a new one each time.
+When the forwarded ref is a *callback* ref, detaching means calling it with
+`null`.
+
+Base UI hands exactly such a callback ref to any part belonging to a composite
+list — a slider thumb, a tab, a menu item — and its cleanup unregisters the item
+and schedules a state update. Render, detach, unregister, render: an infinite
+loop, from a component that is only sitting on the page. Base UI 1.7 is where
+that unregister path began scheduling the update, so that is where it surfaced,
+but the unstable handle was the defect the whole time.
+
+The handle is a getter over a ref that outlives every render, so it depends on
+nothing and is now created once.

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@base-ui/react": "^1.6.0",
+    "@base-ui/react": "^1.7.0",
     "@liqui-design/glass": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/www/e2e/checks.spec.ts
+++ b/apps/www/e2e/checks.spec.ts
@@ -43,6 +43,13 @@ test.describe('no console errors', () => {
     // inside it — and the one place a tail is rendered inside a popup that
     // clips.
     '/docs/components/navigation-menu',
+    // The page that catches an unstable ref forwarded into a composite list. A
+    // slider thumb is a composite item, so a `LiquiGlass` that re-attaches its
+    // handle every render unregisters the thumb every render, and Base UI
+    // schedules a state update each time — an infinite loop on a page nobody
+    // touched. The templates below caught it first, but they catch it three
+    // components deep; this localises it.
+    '/docs/components/slider',
     '/docs/handbook/glass',
     // The templates. A whole page of glass at once is where a surface that
     // misbehaves at density shows up, and the index renders a template inside a

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -15,7 +15,7 @@
     "test:visual:update": "playwright test visual.spec.ts --update-snapshots"
   },
   "dependencies": {
-    "@base-ui/react": "^1.6.0",
+    "@base-ui/react": "^1.7.0",
     "@liqui-design/glass": "workspace:*",
     "@next/third-parties": "^16.3.0",
     "class-variance-authority": "^0.7.1",

--- a/packages/glass/src/LiquiGlass.tsx
+++ b/packages/glass/src/LiquiGlass.tsx
@@ -335,7 +335,22 @@ export const LiquiGlass = React.forwardRef<HTMLDivElement, LiquiGlassProps>(
     const localRef = React.useRef<HTMLDivElement | null>(null);
     const [size, setSize] = React.useState<{ w: number; h: number } | null>(null);
 
-    React.useImperativeHandle(forwardedRef, () => localRef.current as HTMLDivElement);
+    // The empty dependency array is load-bearing. Without it this runs on every
+    // render, and each run detaches the previous handle before attaching the
+    // new one — which, when the forwarded ref is a *callback* ref, means calling
+    // it with `null` and then with the element again, on every render.
+    //
+    // Base UI hands exactly such a callback ref to any part that belongs to a
+    // composite list (a slider thumb, a tab, a menu item), and its cleanup
+    // unregisters the item and schedules a state update. Re-render, detach,
+    // unregister, re-render: "Maximum update depth exceeded", from a component
+    // that is only sitting there. Base UI 1.7 is where the unregister path
+    // started scheduling that update, so that is where this surfaced, but the
+    // unstable handle was always the defect.
+    //
+    // The handle is a getter over a ref that outlives every render, so there is
+    // nothing for it to depend on.
+    React.useImperativeHandle(forwardedRef, () => localRef.current as HTMLDivElement, []);
 
     React.useLayoutEffect(() => {
       if (tier !== 'refract' || !localRef.current) return;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
   apps/playground:
     dependencies:
       '@base-ui/react':
-        specifier: ^1.6.0
-        version: 1.6.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: ^1.7.0
+        version: 1.7.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@liqui-design/glass':
         specifier: workspace:*
         version: link:../../packages/glass
@@ -73,8 +73,8 @@ importers:
   apps/www:
     dependencies:
       '@base-ui/react':
-        specifier: ^1.6.0
-        version: 1.6.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: ^1.7.0
+        version: 1.7.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@liqui-design/glass':
         specifier: workspace:*
         version: link:../../packages/glass
@@ -339,8 +339,8 @@ packages:
     resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
 
-  '@base-ui/react@1.6.0':
-    resolution: {integrity: sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==}
+  '@base-ui/react@1.7.0':
+    resolution: {integrity: sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@date-fns/tz': ^1.2.0
@@ -356,8 +356,8 @@ packages:
       date-fns:
         optional: true
 
-  '@base-ui/utils@0.3.1':
-    resolution: {integrity: sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==}
+  '@base-ui/utils@0.3.2':
+    resolution: {integrity: sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ==}
     peerDependencies:
       '@types/react': ^17 || ^18 || ^19
       react: ^17 || ^18 || ^19
@@ -4552,10 +4552,10 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
-  '@base-ui/react@1.6.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@base-ui/react@1.7.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@base-ui/utils': 0.3.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@base-ui/utils': 0.3.2(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@floating-ui/react-dom': 2.1.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@floating-ui/utils': 0.2.12
       react: 19.2.8
@@ -4564,7 +4564,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.18
 
-  '@base-ui/utils@0.3.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@base-ui/utils@0.3.2(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@floating-ui/utils': 0.2.12


### PR DESCRIPTION
1.7 ships **no new components** — the component set is byte-identical to 1.6, so the registry is untouched. It is a fix release, and a number of the fixes land on components this repo shipped days ago (scroll area thumb drag, drawer swipe, combobox filtering, avatar fallback delay).

## It surfaced a latent bug of ours

Upgrading turned `/templates`, `/templates/media-player` and `/docs/components/slider` red with React #185 — *Maximum update depth exceeded* — from components nobody had touched. The stack was entirely inside Base UI's `CompositeList`:

```
CompositeList.scheduleMapUpdate → unregister → useCompositeListItem ref cleanup → forkRef.cleanup
```

Three steps to place it:

1. **A/B on one machine, one tree.** `^1.6.0` clean, `^1.7.0` throws. The deployed site (1.6) is clean too.
2. **Bisect.** Of thirteen candidate pages only slider and the media player — which uses sliders — fail.
3. **A bare Base UI slider does not reproduce.** So it was ours.

`LiquiGlass` called `useImperativeHandle(forwardedRef, () => localRef.current)` with no dependency array. It therefore re-ran on every render, detaching the old handle and attaching a new one — and when the forwarded ref is a *callback* ref, detaching means calling it with `null`. Base UI hands exactly such a ref to any composite-list part (slider thumb, tab, menu item), and its cleanup unregisters the item and schedules a state update. Render, detach, unregister, render.

1.7 is where that unregister path began scheduling the update, so that is where it surfaced. The unstable handle was the defect the whole time; on 1.6 it was doing the same needless detach-and-reattach every render and getting away with it.

The handle is a getter over a ref that outlives every render, so it now depends on nothing and is created once. **Changeset included** — this is a patch to `@liqui-design/glass`, so merging to `main` will open a Version Packages PR.

## A note on how this was verified

The first local run of `test:checks` was red in a way I initially misread as dev-server slowness. It was not — but the dev server did make it hard to tell, because `/docs/components` lazily compiles sixty demo chunks and five parallel workers time out on it regardless of correctness.

Everything below was therefore run the way CI runs it: `pnpm --filter=www... build && pnpm start`, against the production server.

- `pnpm typecheck`, `pnpm build`, `pnpm --filter www test:checks` → **20 passed** (7.7s).
- By hand on the production build: the scroll-area thumb drags and scrolls the viewport, the combobox filters, the drawer dismisses on a 120px swipe — with **zero filter rebuilds** across all of it, which is the invariant the library rests on.

`/docs/components/slider` joins the console-error checks. The templates caught this already, but they catch it three components deep; the slider page is one step from the cause.
