### PR TITLE
feat(www): report which install commands get copied

### DIFF
--- a/apps/www/components/code-block.tsx
+++ b/apps/www/components/code-block.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import type { ComponentProps } from 'react';
+import { CodeBlock, Pre } from 'fumadocs-ui/components/codeblock';
+
+import { parseInstallCommand, trackInstallCommandCopied } from '@/lib/analytics';
+
+/**
+ * The MDX `pre` — the code block fumadocs already ships, plus one listener.
+ *
+ * fumadocs' CopyButton owns the clipboard write and exposes no callback, so
+ * rather than reimplement copying this watches the <figure> the button lives
+ * in. A click that lands on a button inside a code block is a copy (it is the
+ * only button in there), and the figure's own textContent is the code that was
+ * taken. `onCopy` covers the other route — selecting the line and pressing
+ * ⌘C, which never touches the button and fires no click.
+ *
+ * Both paths hand the text to parseInstallCommand, which reports nothing
+ * unless it is one of ours.
+ */
+export function DocsCodeBlock({ children, ...props }: ComponentProps<'pre'>) {
+  function report(text: string | null | undefined) {
+    const command = parseInstallCommand(text);
+    if (command) trackInstallCommandCopied(command);
+  }
+
+  return (
+    <CodeBlock
+      {...props}
+      onClickCapture={(event) => {
+        if (!(event.target as HTMLElement).closest('button')) return;
+        report(event.currentTarget.textContent);
+      }}
+      onCopy={() => report(window.getSelection()?.toString())}
+    >
+      <Pre>{children}</Pre>
+    </CodeBlock>
+  );
+}

--- a/apps/www/components/mdx.tsx
+++ b/apps/www/components/mdx.tsx
@@ -4,11 +4,15 @@ import { TypeTable } from 'fumadocs-ui/components/type-table';
 import type { MDXComponents } from 'mdx/types';
 
 import { ComponentPreview } from '@/components/component-preview';
+import { DocsCodeBlock } from '@/components/code-block';
 import { ComponentDirectory } from '@/components/component-directory';
 
 export function getMDXComponents(components?: MDXComponents) {
   return {
     ...defaultMdxComponents,
+    // fumadocs' own code block with a copy listener on it, so that taking an
+    // install command away is a measurable event. See components/code-block.tsx.
+    pre: DocsCodeBlock,
     // Available in every page without an import — a component doc that has to
     // import its own preview harness on line 1 invites drift.
     ComponentPreview,

--- a/apps/www/e2e/checks.spec.ts
+++ b/apps/www/e2e/checks.spec.ts
@@ -188,3 +188,62 @@ test.describe('the filter registry', () => {
     await expect.poll(() => page.locator('.liqui-glass--refract').count()).toBeGreaterThan(0);
   });
 });
+
+test.describe('install command tracking', () => {
+  test('copying an install command reports the component, and nothing else does', async ({
+    page,
+    context,
+  }) => {
+    // The event is read out of gtag's dataLayer, which the inline init script
+    // creates. Blocking the tag itself keeps a CI run from filing hits against
+    // the real property while leaving the queue this asserts on intact.
+    await page.route('**://*.googletagmanager.com/**', (route) => route.abort());
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+
+    const events = () =>
+      page.evaluate(() =>
+        ((window as { dataLayer?: ArrayLike<unknown>[] }).dataLayer ?? [])
+          .map((entry) => Array.from(entry))
+          .filter((args) => args[0] === 'event'),
+      );
+
+    await page.goto('/docs/components/button');
+
+    const copy = async (command: string) => {
+      const block = page.locator('figure', { hasText: command }).first();
+      await block.hover();
+      await block.locator('button').first().click();
+    };
+
+    // Retried as a pair: a click that lands before hydration reaches the
+    // listener does nothing, and there is no event to wait for instead. Copying
+    // the same block twice would only push the same event twice, so retrying is
+    // safe — which is why the assertions below are containment rather than
+    // equality.
+    await expect(async () => {
+      await copy('npx shadcn@latest add https://liqui.design/r/button.json');
+      expect(await events()).toContainEqual([
+        'event',
+        'install_command_copied',
+        { component: 'button', command_style: 'url' },
+      ]);
+    }).toPass();
+
+    // The second form the docs publish. Same item, different signal: it means
+    // the visitor registered the namespace and expects to come back.
+    await copy('npx shadcn@latest add @liqui-design/button');
+    expect(await events()).toContainEqual([
+      'event',
+      'install_command_copied',
+      { component: 'button', command_style: 'namespace' },
+    ]);
+
+    // Every code block on the page shares the same listener, so the parser is
+    // what keeps this from becoming a meaningless count of copies. The
+    // components.json snippet contains a registry URL and must still report
+    // nothing.
+    const before = (await events()).length;
+    await copy('"registries"');
+    expect(await events()).toHaveLength(before);
+  });
+});

--- a/apps/www/lib/analytics.ts
+++ b/apps/www/lib/analytics.ts
@@ -1,0 +1,67 @@
+/**
+ * GA4 events the docs send beyond the automatic page views.
+ *
+ * The registry is a pile of static JSON behind a CDN, so a real `shadcn add`
+ * never reaches this site — it resolves against an edge cache on someone
+ * else's machine. What the docs *can* observe is the moment just before: a
+ * visitor taking the install command away. Paired with the page views GA
+ * already records for /docs/components/<name>, that gives a read → intent
+ * funnel per component, which is the closest thing to an install count that
+ * costs nothing to run and adds no request to the critical path.
+ */
+import { sendGAEvent } from '@next/third-parties/google';
+
+/**
+ * The two forms the docs publish. They resolve to the same registry item, and
+ * which one a visitor takes is worth knowing on its own: the URL is a one-off,
+ * while the namespaced form means they registered `@liqui-design` in their
+ * components.json and expect to come back for a second component.
+ */
+export type InstallCommandStyle = 'url' | 'namespace';
+
+export type InstallCommand = {
+  /** Registry item name, as it appears in registry.json — e.g. `button`. */
+  component: string;
+  style: InstallCommandStyle;
+};
+
+const SHADCN_ADD = /\bshadcn(?:@[\w.-]+)?\s+add\s+(\S+)/;
+// Pinned to our own host on purpose. `shadcn add` is the same command for every
+// registry, and the day a doc page tells someone to pull a component from
+// ui.shadcn.com an untightened pattern would quietly file that under our
+// `button`.
+const REGISTRY_URL = /^(?:https?:\/\/(?:[a-z0-9-]+\.)*liqui\.design)?\/r\/([a-z0-9-]+)\.json$/;
+const NAMESPACED = /^@liqui-design\/([a-z0-9-]+)$/;
+
+/**
+ * Reads a copied code block and answers "was that an install command, and for
+ * what". Anything else — the components.json snippet, a usage example, a
+ * shadcn add pointing at somebody else's registry — returns null, because this
+ * is not general "code was copied" tracking and a bare count of copies across
+ * every block on the page would tell us nothing about which component won.
+ */
+export function parseInstallCommand(text: string | null | undefined): InstallCommand | null {
+  const target = text?.match(SHADCN_ADD)?.[1];
+  if (!target) return null;
+
+  const url = target.match(REGISTRY_URL);
+  if (url) return { component: url[1], style: 'url' };
+
+  const namespaced = target.match(NAMESPACED);
+  if (namespaced) return { component: namespaced[1], style: 'namespace' };
+
+  return null;
+}
+
+export function trackInstallCommandCopied({ component, style }: InstallCommand): void {
+  // The GA script is mounted in production builds only (see app/layout.tsx),
+  // and sendGAEvent warns to the console when the dataLayer it wants is not
+  // there. Matching that condition here keeps `next dev` quiet rather than
+  // logging a warning every time someone copies a line locally.
+  if (process.env.NODE_ENV !== 'production') return;
+
+  // `component` and `command_style` are custom parameters: they arrive in
+  // GA immediately, but only appear in reports once registered as custom
+  // dimensions under Admin → Custom definitions.
+  sendGAEvent('event', 'install_command_copied', { component, command_style: style });
+}


### PR DESCRIPTION
The registry is static JSON behind a CDN, so a real `shadcn add` never reaches this site — it resolves against an edge cache on someone else's machine. What the docs *can* observe is the moment just before: a visitor taking the install command away. Paired with the page views GA already records for `/docs/components/<name>`, that is a read → intent funnel per component, at no request on the critical path.

## How it hooks in

The MDX `pre` becomes fumadocs' own code block with one listener on it, so copying still belongs to fumadocs' `CopyButton` and nothing about the clipboard is reimplemented. Two paths reach the listener: a click on the button, and ⌘C over a selection, which fires no click.

`GoogleAnalytics` was already mounted in `app/layout.tsx` (production only) and `@next/third-parties` was already a dependency — this hangs off the existing setup rather than adding one.

## What leaves the browser

The component name and which of the two published forms was taken. Nothing else — **the copied text itself never goes anywhere.**

`parseInstallCommand` matches `shadcn add` against our own host and the `@liqui-design/` namespace, and returns `null` for everything else: a usage example, the `components.json` snippet, a `shadcn add` pointing at somebody else's registry. Two reasons that matters:

- A bare count of copies across every block on a page would say nothing about which component won.
- Pinning the pattern to our own domain keeps the day a doc page tells someone to pull a component from ui.shadcn.com from quietly filing that under our `button`.

The URL form is a one-off; the namespaced form means the visitor registered `@liqui-design` in their `components.json` and expects to come back for a second component. Worth telling apart, which is why `command_style` rides along.

`component` and `command_style` are custom parameters — they reach GA immediately but only surface in reports once registered as custom dimensions under **Admin → Custom definitions**.

## Checks

`pnpm typecheck`, `pnpm build`, and `pnpm --filter www test:checks` → **21 passed**, run against the production build the way CI serves it.

That last part is not incidental. The tracker is a no-op outside production and the `dataLayer` the new check asserts on is created by the GA init script that only mounts there, so this check is meaningless against `next dev`. The tag itself is blocked in the test so a CI run files no hits against the real property.

The negative case is covered too: the `components.json` snippet contains a registry URL and must still report nothing.
