### PR TITLE
release: Base UI 1.7, a stable glass ref, and install-command tracking

### DIFF
--- a/.changeset/quiet-spoons-repeat.md
+++ b/.changeset/quiet-spoons-repeat.md
@@ -1,0 +1,20 @@
+---
+'@liqui-design/glass': patch
+---
+
+Give the forwarded ref a stable imperative handle.
+
+`useImperativeHandle` was called without a dependency array, so it re-ran on
+every render — detaching the previous handle and attaching a new one each time.
+When the forwarded ref is a *callback* ref, detaching means calling it with
+`null`.
+
+Base UI hands exactly such a callback ref to any part belonging to a composite
+list — a slider thumb, a tab, a menu item — and its cleanup unregisters the item
+and schedules a state update. Render, detach, unregister, render: an infinite
+loop, from a component that is only sitting on the page. Base UI 1.7 is where
+that unregister path began scheduling the update, so that is where it surfaced,
+but the unstable handle was the defect the whole time.
+
+The handle is a getter over a ref that outlives every render, so it depends on
+nothing and is now created once.

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@base-ui/react": "^1.6.0",
+    "@base-ui/react": "^1.7.0",
     "@liqui-design/glass": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/www/components/code-block.tsx
+++ b/apps/www/components/code-block.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import type { ComponentProps } from 'react';
+import { CodeBlock, Pre } from 'fumadocs-ui/components/codeblock';
+
+import { parseInstallCommand, trackInstallCommandCopied } from '@/lib/analytics';
+
+/**
+ * The MDX `pre` — the code block fumadocs already ships, plus one listener.
+ *
+ * fumadocs' CopyButton owns the clipboard write and exposes no callback, so
+ * rather than reimplement copying this watches the <figure> the button lives
+ * in. A click that lands on a button inside a code block is a copy (it is the
+ * only button in there), and the figure's own textContent is the code that was
+ * taken. `onCopy` covers the other route — selecting the line and pressing
+ * ⌘C, which never touches the button and fires no click.
+ *
+ * Both paths hand the text to parseInstallCommand, which reports nothing
+ * unless it is one of ours.
+ */
+export function DocsCodeBlock({ children, ...props }: ComponentProps<'pre'>) {
+  function report(text: string | null | undefined) {
+    const command = parseInstallCommand(text);
+    if (command) trackInstallCommandCopied(command);
+  }
+
+  return (
+    <CodeBlock
+      {...props}
+      onClickCapture={(event) => {
+        if (!(event.target as HTMLElement).closest('button')) return;
+        report(event.currentTarget.textContent);
+      }}
+      onCopy={() => report(window.getSelection()?.toString())}
+    >
+      <Pre>{children}</Pre>
+    </CodeBlock>
+  );
+}

--- a/apps/www/components/mdx.tsx
+++ b/apps/www/components/mdx.tsx
@@ -4,11 +4,15 @@ import { TypeTable } from 'fumadocs-ui/components/type-table';
 import type { MDXComponents } from 'mdx/types';
 
 import { ComponentPreview } from '@/components/component-preview';
+import { DocsCodeBlock } from '@/components/code-block';
 import { ComponentDirectory } from '@/components/component-directory';
 
 export function getMDXComponents(components?: MDXComponents) {
   return {
     ...defaultMdxComponents,
+    // fumadocs' own code block with a copy listener on it, so that taking an
+    // install command away is a measurable event. See components/code-block.tsx.
+    pre: DocsCodeBlock,
     // Available in every page without an import — a component doc that has to
     // import its own preview harness on line 1 invites drift.
     ComponentPreview,

--- a/apps/www/e2e/checks.spec.ts
+++ b/apps/www/e2e/checks.spec.ts
@@ -43,6 +43,13 @@ test.describe('no console errors', () => {
     // inside it — and the one place a tail is rendered inside a popup that
     // clips.
     '/docs/components/navigation-menu',
+    // The page that catches an unstable ref forwarded into a composite list. A
+    // slider thumb is a composite item, so a `LiquiGlass` that re-attaches its
+    // handle every render unregisters the thumb every render, and Base UI
+    // schedules a state update each time — an infinite loop on a page nobody
+    // touched. The templates below caught it first, but they catch it three
+    // components deep; this localises it.
+    '/docs/components/slider',
     '/docs/handbook/glass',
     // The templates. A whole page of glass at once is where a surface that
     // misbehaves at density shows up, and the index renders a template inside a

--- a/apps/www/e2e/checks.spec.ts
+++ b/apps/www/e2e/checks.spec.ts
@@ -188,3 +188,62 @@ test.describe('the filter registry', () => {
     await expect.poll(() => page.locator('.liqui-glass--refract').count()).toBeGreaterThan(0);
   });
 });
+
+test.describe('install command tracking', () => {
+  test('copying an install command reports the component, and nothing else does', async ({
+    page,
+    context,
+  }) => {
+    // The event is read out of gtag's dataLayer, which the inline init script
+    // creates. Blocking the tag itself keeps a CI run from filing hits against
+    // the real property while leaving the queue this asserts on intact.
+    await page.route('**://*.googletagmanager.com/**', (route) => route.abort());
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+
+    const events = () =>
+      page.evaluate(() =>
+        ((window as { dataLayer?: ArrayLike<unknown>[] }).dataLayer ?? [])
+          .map((entry) => Array.from(entry))
+          .filter((args) => args[0] === 'event'),
+      );
+
+    await page.goto('/docs/components/button');
+
+    const copy = async (command: string) => {
+      const block = page.locator('figure', { hasText: command }).first();
+      await block.hover();
+      await block.locator('button').first().click();
+    };
+
+    // Retried as a pair: a click that lands before hydration reaches the
+    // listener does nothing, and there is no event to wait for instead. Copying
+    // the same block twice would only push the same event twice, so retrying is
+    // safe — which is why the assertions below are containment rather than
+    // equality.
+    await expect(async () => {
+      await copy('npx shadcn@latest add https://liqui.design/r/button.json');
+      expect(await events()).toContainEqual([
+        'event',
+        'install_command_copied',
+        { component: 'button', command_style: 'url' },
+      ]);
+    }).toPass();
+
+    // The second form the docs publish. Same item, different signal: it means
+    // the visitor registered the namespace and expects to come back.
+    await copy('npx shadcn@latest add @liqui-design/button');
+    expect(await events()).toContainEqual([
+      'event',
+      'install_command_copied',
+      { component: 'button', command_style: 'namespace' },
+    ]);
+
+    // Every code block on the page shares the same listener, so the parser is
+    // what keeps this from becoming a meaningless count of copies. The
+    // components.json snippet contains a registry URL and must still report
+    // nothing.
+    const before = (await events()).length;
+    await copy('"registries"');
+    expect(await events()).toHaveLength(before);
+  });
+});

--- a/apps/www/lib/analytics.ts
+++ b/apps/www/lib/analytics.ts
@@ -1,0 +1,67 @@
+/**
+ * GA4 events the docs send beyond the automatic page views.
+ *
+ * The registry is a pile of static JSON behind a CDN, so a real `shadcn add`
+ * never reaches this site — it resolves against an edge cache on someone
+ * else's machine. What the docs *can* observe is the moment just before: a
+ * visitor taking the install command away. Paired with the page views GA
+ * already records for /docs/components/<name>, that gives a read → intent
+ * funnel per component, which is the closest thing to an install count that
+ * costs nothing to run and adds no request to the critical path.
+ */
+import { sendGAEvent } from '@next/third-parties/google';
+
+/**
+ * The two forms the docs publish. They resolve to the same registry item, and
+ * which one a visitor takes is worth knowing on its own: the URL is a one-off,
+ * while the namespaced form means they registered `@liqui-design` in their
+ * components.json and expect to come back for a second component.
+ */
+export type InstallCommandStyle = 'url' | 'namespace';
+
+export type InstallCommand = {
+  /** Registry item name, as it appears in registry.json — e.g. `button`. */
+  component: string;
+  style: InstallCommandStyle;
+};
+
+const SHADCN_ADD = /\bshadcn(?:@[\w.-]+)?\s+add\s+(\S+)/;
+// Pinned to our own host on purpose. `shadcn add` is the same command for every
+// registry, and the day a doc page tells someone to pull a component from
+// ui.shadcn.com an untightened pattern would quietly file that under our
+// `button`.
+const REGISTRY_URL = /^(?:https?:\/\/(?:[a-z0-9-]+\.)*liqui\.design)?\/r\/([a-z0-9-]+)\.json$/;
+const NAMESPACED = /^@liqui-design\/([a-z0-9-]+)$/;
+
+/**
+ * Reads a copied code block and answers "was that an install command, and for
+ * what". Anything else — the components.json snippet, a usage example, a
+ * shadcn add pointing at somebody else's registry — returns null, because this
+ * is not general "code was copied" tracking and a bare count of copies across
+ * every block on the page would tell us nothing about which component won.
+ */
+export function parseInstallCommand(text: string | null | undefined): InstallCommand | null {
+  const target = text?.match(SHADCN_ADD)?.[1];
+  if (!target) return null;
+
+  const url = target.match(REGISTRY_URL);
+  if (url) return { component: url[1], style: 'url' };
+
+  const namespaced = target.match(NAMESPACED);
+  if (namespaced) return { component: namespaced[1], style: 'namespace' };
+
+  return null;
+}
+
+export function trackInstallCommandCopied({ component, style }: InstallCommand): void {
+  // The GA script is mounted in production builds only (see app/layout.tsx),
+  // and sendGAEvent warns to the console when the dataLayer it wants is not
+  // there. Matching that condition here keeps `next dev` quiet rather than
+  // logging a warning every time someone copies a line locally.
+  if (process.env.NODE_ENV !== 'production') return;
+
+  // `component` and `command_style` are custom parameters: they arrive in
+  // GA immediately, but only appear in reports once registered as custom
+  // dimensions under Admin → Custom definitions.
+  sendGAEvent('event', 'install_command_copied', { component, command_style: style });
+}

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -15,7 +15,7 @@
     "test:visual:update": "playwright test visual.spec.ts --update-snapshots"
   },
   "dependencies": {
-    "@base-ui/react": "^1.6.0",
+    "@base-ui/react": "^1.7.0",
     "@liqui-design/glass": "workspace:*",
     "@next/third-parties": "^16.3.0",
     "class-variance-authority": "^0.7.1",

--- a/packages/glass/src/LiquiGlass.tsx
+++ b/packages/glass/src/LiquiGlass.tsx
@@ -335,7 +335,22 @@ export const LiquiGlass = React.forwardRef<HTMLDivElement, LiquiGlassProps>(
     const localRef = React.useRef<HTMLDivElement | null>(null);
     const [size, setSize] = React.useState<{ w: number; h: number } | null>(null);
 
-    React.useImperativeHandle(forwardedRef, () => localRef.current as HTMLDivElement);
+    // The empty dependency array is load-bearing. Without it this runs on every
+    // render, and each run detaches the previous handle before attaching the
+    // new one — which, when the forwarded ref is a *callback* ref, means calling
+    // it with `null` and then with the element again, on every render.
+    //
+    // Base UI hands exactly such a callback ref to any part that belongs to a
+    // composite list (a slider thumb, a tab, a menu item), and its cleanup
+    // unregisters the item and schedules a state update. Re-render, detach,
+    // unregister, re-render: "Maximum update depth exceeded", from a component
+    // that is only sitting there. Base UI 1.7 is where the unregister path
+    // started scheduling that update, so that is where this surfaced, but the
+    // unstable handle was always the defect.
+    //
+    // The handle is a getter over a ref that outlives every render, so there is
+    // nothing for it to depend on.
+    React.useImperativeHandle(forwardedRef, () => localRef.current as HTMLDivElement, []);
 
     React.useLayoutEffect(() => {
       if (tier !== 'refract' || !localRef.current) return;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
   apps/playground:
     dependencies:
       '@base-ui/react':
-        specifier: ^1.6.0
-        version: 1.6.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: ^1.7.0
+        version: 1.7.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@liqui-design/glass':
         specifier: workspace:*
         version: link:../../packages/glass
@@ -73,8 +73,8 @@ importers:
   apps/www:
     dependencies:
       '@base-ui/react':
-        specifier: ^1.6.0
-        version: 1.6.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: ^1.7.0
+        version: 1.7.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@liqui-design/glass':
         specifier: workspace:*
         version: link:../../packages/glass
@@ -339,8 +339,8 @@ packages:
     resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
 
-  '@base-ui/react@1.6.0':
-    resolution: {integrity: sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==}
+  '@base-ui/react@1.7.0':
+    resolution: {integrity: sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@date-fns/tz': ^1.2.0
@@ -356,8 +356,8 @@ packages:
       date-fns:
         optional: true
 
-  '@base-ui/utils@0.3.1':
-    resolution: {integrity: sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==}
+  '@base-ui/utils@0.3.2':
+    resolution: {integrity: sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ==}
     peerDependencies:
       '@types/react': ^17 || ^18 || ^19
       react: ^17 || ^18 || ^19
@@ -4552,10 +4552,10 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
-  '@base-ui/react@1.6.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@base-ui/react@1.7.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@base-ui/utils': 0.3.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@base-ui/utils': 0.3.2(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@floating-ui/react-dom': 2.1.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@floating-ui/utils': 0.2.12
       react: 19.2.8
@@ -4564,7 +4564,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.18
 
-  '@base-ui/utils@0.3.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@base-ui/utils@0.3.2(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@floating-ui/utils': 0.2.12


### PR DESCRIPTION
Promotes #22 and #23.

## Base UI 1.7.0 (#22)

1.7 ships **no new components** — the set is identical to 1.6, so the registry is untouched. It is a fix release, and several of the fixes land on components shipped days ago: scroll-area thumb drag (a divide-by-zero and a per-scroll re-render), drawer swipe reliability, combobox list-scroll and highlight behaviour, `<Avatar.Fallback>` at `delay={0}`.

### It surfaced a latent bug of ours

Upgrading turned `/templates`, `/templates/media-player` and `/docs/components/slider` red with React #185 — *Maximum update depth exceeded* — from components nobody had touched, with a stack entirely inside Base UI's `CompositeList`.

`LiquiGlass` called `useImperativeHandle(forwardedRef, () => localRef.current)` **with no dependency array**, so it re-ran every render: detach the old handle, attach a new one. When the forwarded ref is a *callback* ref, detaching means calling it with `null` — and Base UI hands exactly such a ref to any composite-list part (slider thumb, tab, menu item), whose cleanup unregisters the item and schedules a state update. Render, detach, unregister, render.

1.7 is where that unregister path began scheduling the update, so that is where it surfaced. The unstable handle was the defect the whole time; on 1.6 it was doing the same needless work every render and getting away with it.

**Changeset included** — `@liqui-design/glass` patch, so merging opens a Version Packages PR (0.2.3 → 0.2.4).

## Install-command tracking (#23)

The registry is static JSON behind a CDN, so a real `shadcn add` never reaches this site. What the docs *can* observe is the moment before: a visitor taking the install command away. With the page views GA already records, that is a read → intent funnel per component.

What leaves the browser is the component name and which of the two published forms was taken — **never the copied text**. `parseInstallCommand` matches `shadcn add` against our own host and the `@liqui-design/` namespace and returns null for everything else, including the `components.json` snippet, which contains a registry URL and must still report nothing.

## Checks

Both PRs were green on all six. Locally, against the production build the way CI serves it: `pnpm typecheck`, `pnpm build`, `pnpm --filter www test:checks` → **21 passed**.

Two additions to the CI check list: `/docs/components/slider` (a slider thumb is a composite item, so it is one step from the ref bug's cause — the templates caught it, but three components deep) and the install-command tracking assertion.

## Note on the after-merge run

The `Checks` run for dev's merge commit is wedged on *Initialize containers* — the Playwright image pull — and has not started the suite after 25 minutes; a cancel request could not be processed either. That is infrastructure, not code: the same tree passed on #23 minutes earlier.

Nothing is skipped by promoting now. This PR runs the identical suite, and main's ruleset requires those four contexts to pass before it can merge — the enforced gate is here, not on the after-merge run.
