### PR TITLE
feat(www): rebuild Switch and Slider on a purpose-built lens

### DIFF
--- a/apps/playground/src/App.tsx
+++ b/apps/playground/src/App.tsx
@@ -185,6 +185,12 @@ export default function App() {
   const [lastAction, setLastAction] = React.useState<string | null>(null);
   const [glass, setGlass] = React.useState<GlassOptics>(initialSettings);
 
+  // Switch and Slider are not LiquiGlass surfaces — they carry their own lens
+  // (see registry/liqui/lib/lens.tsx), so the geometric dials on the panel mean
+  // nothing to them. Material still does: it is the one control that says
+  // whether a surface refracts at all, so it drives their `lens` instead.
+  const lensOn = glass.material === 'auto';
+
   React.useEffect(() => {
     document.documentElement.dataset.theme = theme;
   }, [theme]);
@@ -320,15 +326,15 @@ export default function App() {
             <div className="stage__checks">
               <SwitchLabel>
                 Snap to grid
-                <Switch glass={glass} checked={snapToGrid} onCheckedChange={setSnapToGrid} />
+                <Switch lens={lensOn} checked={snapToGrid} onCheckedChange={setSnapToGrid} />
               </SwitchLabel>
               <SwitchLabel>
                 Show hidden files
-                <Switch glass={glass} checked={showHidden} onCheckedChange={setShowHidden} />
+                <Switch lens={lensOn} checked={showHidden} onCheckedChange={setShowHidden} />
               </SwitchLabel>
               <SwitchLabel>
                 Unavailable
-                <Switch glass={glass} disabled />
+                <Switch lens={lensOn} disabled />
               </SwitchLabel>
             </div>
 
@@ -341,7 +347,7 @@ export default function App() {
                 </div>
                 <SliderControl>
                   <SliderTrack>
-                    <SliderThumb glass={glass} />
+                    <SliderThumb lens={lensOn} />
                   </SliderTrack>
                 </SliderControl>
               </Slider>
@@ -353,8 +359,8 @@ export default function App() {
                 </div>
                 <SliderControl>
                   <SliderTrack>
-                    <SliderThumb glass={glass} index={0} getAriaLabel={() => 'Minimum'} />
-                    <SliderThumb glass={glass} index={1} getAriaLabel={() => 'Maximum'} />
+                    <SliderThumb lens={lensOn} index={0} getAriaLabel={() => 'Minimum'} />
+                    <SliderThumb lens={lensOn} index={1} getAriaLabel={() => 'Maximum'} />
                   </SliderTrack>
                 </SliderControl>
               </Slider>
@@ -471,19 +477,11 @@ export default function App() {
                   <div className="stage__checks" style={{ marginTop: 14 }}>
                     <SwitchLabel>
                       Mentions
-                      <Switch
-                        glass={{ ...glass, material: 'clear' }}
-                        checked={showHidden}
-                        onCheckedChange={setShowHidden}
-                      />
+                      <Switch lens={false} checked={showHidden} onCheckedChange={setShowHidden} />
                     </SwitchLabel>
                     <SwitchLabel>
                       Replies
-                      <Switch
-                        glass={{ ...glass, material: 'clear' }}
-                        checked={snapToGrid}
-                        onCheckedChange={setSnapToGrid}
-                      />
+                      <Switch lens={false} checked={snapToGrid} onCheckedChange={setSnapToGrid} />
                     </SwitchLabel>
                   </div>
                 </PopoverContent>

--- a/apps/playground/tsconfig.json
+++ b/apps/playground/tsconfig.json
@@ -9,6 +9,7 @@
       "@registry/*": ["../www/registry/liqui/*"],
       "@shared/*": ["../www/components/*"],
       "@/lib/utils": ["../www/registry/liqui/lib/utils.ts"],
+      "@/lib/lens": ["../www/registry/liqui/lib/lens.tsx"],
       "@/registry/*": ["../www/registry/*"]
     }
   },

--- a/apps/playground/vite.config.ts
+++ b/apps/playground/vite.config.ts
@@ -40,6 +40,8 @@ export default defineConfig({
       // Registry components import `cn` from where the CLI puts it in a consumer
       // project, so that specifier has to resolve here too.
       { find: /^@\/lib\/utils$/, replacement: resolve('../www/registry/liqui/lib/utils.ts') },
+      // Same again for the lens kernel that Switch and Slider share.
+      { find: /^@\/lib\/lens$/, replacement: resolve('../www/registry/liqui/lib/lens.tsx') },
       // Same reason, for the components that import each other: toggle-group
       // reaches for toggle by the specifier the CLI rewrites into
       // `@/components/ui/toggle`, so it has to resolve here too.

--- a/apps/www/content/docs/components/slider.mdx
+++ b/apps/www/content/docs/components/slider.mdx
@@ -1,29 +1,18 @@
 ---
 title: Slider
-description: A slider whose thumb is the refracting surface, sliding along a flat rail.
+description: A convex-lens thumb that magnifies the rail it rides, swelling out of it when grabbed.
 ---
 
 <ComponentPreview name="slider-demo" />
+
+<Callout>Grab the thumb and hold. It swells to nearly twice its size, its white
+fill drops to a tenth, and the rail visibly fattens as it passes behind the
+glass.</Callout>
 
 ## Installation
 
 ```bash
 npx shadcn@latest add https://liqui.design/r/slider.json
-```
-
-Installing more than one? Register the namespace once in `components.json` and
-drop the URLs:
-
-```json title="components.json"
-{
-  "registries": {
-    "@liqui-design": "https://liqui.design/r/{name}.json"
-  }
-}
-```
-
-```bash
-npx shadcn@latest add @liqui-design/slider
 ```
 
 ## Usage
@@ -53,63 +42,113 @@ import {
 </Slider>
 ```
 
-`SliderTrack` renders `Slider.Indicator` for you — the accent fill is part of
-the rail, not something you compose in.
+Two thumbs make it a range — see [the range example](#range).
+
+## Notes
+
+### Convex, where Switch is lipped
+
+This and [Switch](/docs/components/switch) are the same construction: a
+purpose-built lens rather than a [`LiquiGlass`](/docs/handbook/glass) surface,
+sharing only the kernel in `lib/lens.tsx`. What differs between them is the
+interesting part, and it is not cosmetic.
+
+A switch thumb has nothing worth magnifying under it, so it takes a **lip**
+bezel — a raised rim around a flat window, which reads *zoomed out*. A slider
+thumb is sitting on the one thing in the control you actually want to look at:
+the rail, and the fill that says where the value is. So it takes a plain
+**convex** dome instead, and magnifies it. Grab one and the rail fattens as it
+crosses the glass.
+
+### The exponent is the tail
+
+The dome is a superellipse, `(1 − (1 − t)ᵖ)^(1/p)`, and `p` is not a
+free-hand choice. It sets how fast the surface flattens as it leaves the rim,
+which is to say how far inward the bend still reaches.
+
+A squircle (`p = 4`) — the obvious pick, and what Switch's crest uses —
+flattens too abruptly here: its slope collapses, the bend dies within a few
+pixels of the edge, and the long reach this lens needs is not available at any
+thickness. A circle (`p = 2`) misses the other end, at the rim. `p = 3.25`
+holds both.
+
+| Profile | Error against the reference's own map |
+| --- | --- |
+| Squircle, best thickness | 1.84px RMS |
+| Circle, best thickness | 4.54px RMS |
+| **Superellipse p = 3.25** | **0.49px RMS** |
+
+Against a 70px peak — so 0.7%.
+
+### How hard the edge bends
+
+The band is 42% of the lens's radius, and inside it the outermost pixels sample
+from **more than a lens-height away** — 118% of it. That is what turns the
+rail's straight edge into the curled lip of a real piece of thick glass rather
+than a soft smear, and it is far more than the switch asks for, because a
+slider has something behind it worth dragging into view.
+
+The filter declares no region for the same reason Switch's does not: the SVG
+default is the bounding box plus 10%, and pinning it to the element would have
+Chromium clamp those long samples at the boundary.
+
+### Grabbed-ness comes from Base UI
+
+The press state is read off Base UI's own `data-dragging`, watched with a
+MutationObserver, rather than from pointer events on the thumb.
+
+That is not a shortcut, it is the correct source. Base UI already starts a drag
+when you press the *rail* — the thumb jumps to your finger and follows it — and
+a thumb listening only to its own pointer events would sit there un-grabbed
+through the whole gesture.
+
+### The rail is flat
+
+No inset groove, no glass. It is the thumb's backdrop, and a lens stacked on a
+lens samples its parent's output instead of the page. Whatever depth this
+control has comes from the thumb; a rail with its own shadow only competes with
+the lens passing over it.
+
+The neutral grey is fixed rather than mixed from `--lq-text`, so it reads the
+same on a white sheet and a dark wallpaper. Override `--lq-slider-rail` for the
+rail and `--lq-accent` for the fill.
+
+### Turning the lens off
+
+```tsx
+<SliderThumb lens={false} className="size-[18px]" />
+```
+
+Refraction is not worth its cost for a slider sitting *on* another glass
+surface — inside a popover, a drawer, a media-player panel — because
+`backdrop-filter` samples what is painted behind the element, and behind a
+thumb on a frosted panel is the panel's own tint: a flat wash with nothing in
+it to bend. Without the lens the thumb takes its size from `className`, so a
+panel can ask for a small knob.
+
+Safari and Firefox take this path on their own — `backdrop-filter: url(#…)` is
+Chromium-only.
+
+### Sizing
+
+```tsx
+const RAIL_H = 14;
+```
+
+The only number to change. The lens box, its radius, the resting size, the
+band and the peak displacement are all ratios off it — and the root publishes
+the layout ones as custom properties (`--lq-rail-h`, `--lq-knob-w`,
+`--lq-knob-h`, `--lq-knob-pad`) rather than inline styles, so the rail and the
+hit area still follow `RAIL_H` while a caller's `className="h-2"` still wins.
+
+The lens itself is the exception: its box is inline and not overridable,
+because the maps are baked for exactly that size. If you want a smaller knob on
+a panel, that is what `lens={false}` is for.
+
+The thumb is deliberately enormous next to the rail — four times its height
+even at rest, seven times when grabbed. A lens the size of the thing it sits on
+has nothing to show.
 
 ## Range
 
 <ComponentPreview name="slider-range" />
-
-Two thumbs, two `index` props. They are the same size, so they resolve to the
-same cached displacement map and the same registered filter — a range slider
-costs one map, not two.
-
-## Notes
-
-### The thumb is the glass, the rail is not
-
-[Switch](/docs/components/switch#only-one-of-the-two-can-be-a-lens) explains the
-constraint: a `backdrop-filter` nested inside another one samples its parent's
-output rather than the page, so a thumb inside a glass track would refract the
-track.
-
-A slider resolves it the other way. The moving part is the one worth looking at,
-so `SliderThumb` is a `LiquiGlass` surface and `SliderTrack` is drawn the cheap
-way — a tinted groove with an inset shadow:
-
-```tsx
-'bg-[color-mix(in_srgb,var(--lq-text)_14%,transparent)]',
-'shadow-[inset_0_1px_2px_...,inset_0_0_0_0.5px_var(--lq-rim-lo)]',
-```
-
-Because the rail has no backdrop filter of its own, everything under the thumb —
-rail, accent fill and the page behind both — reaches the lens as ordinary
-backdrop and bends together. Drag the thumb past the end of the fill and watch
-the bezel pick up the background instead.
-
-<Callout type="info">
-  If you want the rail to be glass too, make it the `LiquiGlass` and drop the
-  thumb to an opaque puck — the switch anatomy. What does not work is both.
-</Callout>
-
-### Dragging is free
-
-The map is keyed on size and optics. Neither changes while a thumb moves, so an
-entire drag reuses one cached map and one filter; nothing is regenerated per
-frame. This is the same invariant the home page's drag test asserts — a fade
-class reappearing mid-drag would mean a filter had been rebuilt on a plain
-translate.
-
-### Positioning comes from Base UI
-
-`Slider.Thumb` writes `position`, `inset` and `translate` as inline styles to
-place itself along the track. `SliderThumb` hands the glass over through
-`render`, and `LiquiGlass` spreads the `style` it receives, so those survive the
-substitution. Anything you set in a `style` prop of your own merges the same
-way — but do not set `position`, or the thumb stops tracking its value.
-
-### Hit area
-
-`SliderControl` carries `py-2.5`. The rail is 12px tall and the thumb 26px, so
-without that padding the control's box would be shorter than the thing you are
-trying to grab and the top and bottom of the thumb would not be draggable.

--- a/apps/www/content/docs/components/switch.mdx
+++ b/apps/www/content/docs/components/switch.mdx
@@ -1,9 +1,13 @@
 ---
 title: Switch
-description: A switch whose glass track retints with accent, carrying an opaque thumb.
+description: An opaque white pill at rest that swells out of its track and turns to glass under your finger.
 ---
 
 <ComponentPreview name="switch-demo" />
+
+<Callout>Press and hold a switch, or drag the thumb across. It swells past the
+track, its white fill drops to a tenth, and the refraction more than doubles —
+so the lens deepens as it is uncovered.</Callout>
 
 ## Installation
 
@@ -46,43 +50,148 @@ being told about the switch's state.
 
 ## Notes
 
-### Only one of the two can be a lens
+### This one is not a glass surface
 
-A switch is a thumb inside a track, and `backdrop-filter` samples whatever is
-painted *behind* an element. For a thumb sitting inside a glass track, that
-backdrop is the track's own tint — not the page. Make both glass and the thumb
-refracts the colour it is lying on: a smudge, not a lens.
+Every other component here is a [`LiquiGlass`](/docs/handbook/glass) box: one
+shared displacement map, one shared filter, one set of dials that has to suit a
+drawer and a scrollbar thumb at the same time. This is not built out of that
+and does not import it. Only the `--lq-*` tokens are shared, through CSS, so it
+still themes with everything else.
 
-So the track is the surface and the thumb is opaque white, with its own cast
-shadow because the glass layers underneath give a child no depth of their own.
+It needs three things the shared surface does not have and should not grow:
 
-[Slider](/docs/components/slider) has exactly the same conflict and resolves it
-the other way round: there the moving part is the interesting one, so the thumb
-is the glass and the rail is flattened. The rule to carry away is that **one
-surface per control gets to refract** — pick the one that matters.
+| | Shared surface | Switch |
+| --- | --- | --- |
+| Bezel | Convex — magnifies its middle | **Lip** — a band at the rim, flat middle |
+| Refraction | A fixed prop | **Animated** every frame, 0.4× → 0.9× |
+| Specular | A white rim, composited in the DOM | **The backdrop at 6× saturation**, masked to a hairline |
 
-### On/off is a retint
+### Only the band refracts
 
-Switching on doesn't swap the track for a filled pill. It overrides `--lq-tint`
-on the root, so the accent arrives *as glass* and the bezel and specular arc
-survive the transition:
+The thumb's surface is convex at the very rim, eases into a shallow concave
+bowl, and then goes flat. The band is 41% of the thumb's radius; the middle
+59% is a genuinely neutral window that moves nothing at all.
+
+That flat middle is the point. The two halves of the band refract in opposite
+directions — the crest pulls the backdrop inward the way any lens edge does,
+the bowl pushes it back out — and what makes that read as *glass* rather than
+as *smear* is having an undistorted window to see it against. A lens that
+distorts everywhere just looks broken.
+
+The outermost ring of pixels samples from nearly a third of the way across the
+thumb, which is why the track's edge appears to wrap around the glass instead
+of merely blurring past it.
+
+### The filter declares no region
 
 ```tsx
-data-[checked]:[--lq-tint:color-mix(in_srgb,var(--lq-accent)_88%,transparent)]
+<filter id={filterId} colorInterpolationFilters="sRGB">
 ```
 
-Same mechanism as [Checkbox](/docs/components/checkbox#checked-state). Retint
-through the token if you want a different on-colour; a `background` would paint
-over the refraction instead of joining it.
+No `x`, no `width`, no `filterUnits`. The SVG default is the bounding box plus
+10%, and the bowl needs that margin: it samples *outward*, past the thumb's own
+edge. Pin the region to the element and Chromium clamps those samples at the
+boundary, turning the bowl into a smeared ring.
+
+### A hairline, not an arc
+
+The specular is one axis of light falling off as `cos²` around the outward
+normal, laid on a rim about a pixel wide just inside the edge.
+
+It is tempting to model it as a lit surface instead, and it is wrong. A flat
+patch of glass faces the viewer, and a viewer-facing normal still scores well
+against a light tilted toward the camera — so the whole middle of the thumb
+picks up a fifth of full highlight, the shallow bowl adds a broad lobe on top,
+and once that becomes the mask for the saturation pass below, the lens is
+delivered wearing a vivid film.
+
+### The rim is coloured, and that is the point
+
+The specular is composited inside the filter, not stacked as a DOM layer, so it
+can be masked over something other than white:
+
+```
+bend → saturate 6× → keep only what the rim mask covers → blend over the bend
+                                                        → white light on top
+```
+
+A white rim reads as plastic. A rim that is the backdrop's own colour pushed
+until it sings reads as a wet edge.
+
+### The thumb is drawn at 0.65
+
+Its layout box is half again as big as it ever looks. That is not a trick to
+avoid a re-layout — it is why the map has resolution left when the thumb swells
+to 0.9, and why the refraction grows with it: `backdrop-filter` is applied in
+the element's own coordinates and scales with everything else.
+
+At 0.9 the thumb is *taller than its track*, and breaks out of it top and
+bottom. Nothing clips it — the root sets no `overflow` and no `isolation`,
+because the thumb's backdrop has to reach the page rather than stop at the
+track.
+
+The white fill is the element's own background, which paints *above* the
+backdrop. That one value is the whole reveal: opaque and the thumb is a white
+pill, a tenth and it is a lens.
+
+### Drag
+
+The thumb follows your finger with no spring in between — a spring there reads
+as lag rather than life — and runs past either end on a rubber band, so the
+track has a floor and a ceiling you can feel.
+
+A drag and a tap both end in a `click`, and Base UI toggles on click. A drag
+that lands on the far side wants exactly that toggle, so it is let through; a
+drag that returns to the side it started on wants nothing to happen, so the
+click is swallowed on the way up. The state is never written twice, and a
+controlled switch still gets to refuse the change.
+
+### Motion
+
+Three springs, integrated per frame and written straight to the DOM:
+
+| | Spring (mass 1) | ζ | Drives |
+| --- | --- | --- | --- |
+| Travel | k 1000, c 80 | 1.27 | Thumb position |
+| Press | k 2000, c 80 | 0.89 | Refraction, scale, fill, shadow |
+| Tint | k 1000, c 80 | 1.27 | Track colour |
+
+The track colour gets its own spring because it is not the thumb's position: it
+flips the moment a drag crosses the middle and then travels on its own, rather
+than fading through a half-tinted track on the way across.
+
+CSS could not do any of it. Travel has to be interruptible mid-flight by a
+drag, and press drives an SVG attribute — `feDisplacementMap scale` — that CSS
+cannot animate at all. `prefers-reduced-motion` snaps all three.
+
+### Turning the lens off
+
+```tsx
+<Switch lens={false} />
+```
+
+There is one place refraction is not worth its cost: a switch sitting *on*
+another glass surface — inside a popover, a drawer, a media-player panel.
+`backdrop-filter` samples what is painted behind the element, and behind a
+switch on a frosted panel is the panel's own tint: a flat wash with nothing in
+it to bend.
+
+Safari and Firefox take this path on their own — `backdrop-filter: url(#…)` is
+Chromium-only. Either way the thumb stays a white pill with a cast shadow, and
+the press keeps its swell but gives up the reveal.
 
 ### Sizing
 
-The travel distance is hard-coded to the default box:
-
-```
-52px track − 2×2px padding − 26px thumb = 22px
+```tsx
+const TRACK_H = 34;
 ```
 
-If you resize the switch, `data-[checked]:translate-x-[22px]` and the glass
-`radius` both need to move with it. They are in one file — that is the point of
-the component landing in your repo.
+That is the only number to change. Everything else — track width, thumb box,
+radius, travel, band width, peak displacement — is a ratio off it, and the maps
+regenerate to match.
+
+The ratios are not invented, and they are not iOS's. The track is 2.39× as long
+as it is tall and the thumb is a capsule far wider than the track is tall,
+because that is what gives the lens enough glass to be worth looking through.
+Two colours are exposed: `--lq-switch-off` for the track, `--lq-accent` for the
+checked fill.

--- a/apps/www/lib/lens.ts
+++ b/apps/www/lib/lens.ts
@@ -1,0 +1,6 @@
+/**
+ * Registry components import the lens kernel from `@/lib/lens` because that is
+ * where the shadcn CLI puts it in a consumer project. The docs site has to
+ * satisfy the same specifier so the very same file compiles here and there.
+ */
+export * from '@/registry/liqui/lib/lens';

--- a/apps/www/registry.json
+++ b/apps/www/registry.json
@@ -8,8 +8,14 @@
       "type": "registry:style",
       "title": "liqui",
       "description": "Liquid glass surfaces for Base UI. Installs the refraction kernel and the glass design tokens.",
-      "dependencies": ["@base-ui/react", "@liqui-design/glass", "class-variance-authority"],
-      "registryDependencies": ["utils"],
+      "dependencies": [
+        "@base-ui/react",
+        "@liqui-design/glass",
+        "class-variance-authority"
+      ],
+      "registryDependencies": [
+        "utils"
+      ],
       "files": [],
       "cssVars": {
         "theme": {
@@ -51,7 +57,10 @@
       "type": "registry:lib",
       "title": "cn",
       "description": "clsx + tailwind-merge class combiner.",
-      "dependencies": ["clsx", "tailwind-merge"],
+      "dependencies": [
+        "clsx",
+        "tailwind-merge"
+      ],
       "files": [
         {
           "path": "registry/liqui/lib/utils.ts",
@@ -61,13 +70,36 @@
       ]
     },
     {
+      "name": "lens",
+      "type": "registry:lib",
+      "title": "Lens kernel",
+      "description": "Refraction kernel for the small controls: glass profiles, displacement and specular maps, the SVG filter chain, and a spring integrator.",
+      "dependencies": [],
+      "files": [
+        {
+          "path": "registry/liqui/lib/lens.tsx",
+          "type": "registry:lib",
+          "target": "@lib/lens.tsx"
+        }
+      ]
+    },
+    {
       "name": "button",
       "type": "registry:ui",
       "title": "Glass Button",
       "description": "A button rendered as a refracting glass surface, with accent and danger tints.",
-      "meta": { "added": "2026-08-06" },
-      "dependencies": ["@base-ui/react", "@liqui-design/glass", "class-variance-authority"],
-      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
+      "meta": {
+        "added": "2026-08-06"
+      },
+      "dependencies": [
+        "@base-ui/react",
+        "@liqui-design/glass",
+        "class-variance-authority"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/liqui.json",
+        "utils"
+      ],
       "files": [
         {
           "path": "registry/liqui/ui/button.tsx",
@@ -81,11 +113,23 @@
       "type": "registry:ui",
       "title": "Glass Checkbox",
       "description": "A checkbox whose glass fills with accent when checked, keeping the bezel and rim light.",
-      "meta": { "added": "2026-08-06" },
-      "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
+      "meta": {
+        "added": "2026-08-06"
+      },
+      "dependencies": [
+        "@base-ui/react",
+        "@liqui-design/glass"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/liqui.json",
+        "utils"
+      ],
       "files": [
-        { "path": "registry/liqui/ui/checkbox.tsx", "type": "registry:ui", "target": "@ui/checkbox.tsx" }
+        {
+          "path": "registry/liqui/ui/checkbox.tsx",
+          "type": "registry:ui",
+          "target": "@ui/checkbox.tsx"
+        }
       ]
     },
     {
@@ -93,11 +137,23 @@
       "type": "registry:ui",
       "title": "Glass Field",
       "description": "A labelled form field whose control sits on its own glass surface.",
-      "meta": { "added": "2026-08-06" },
-      "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
+      "meta": {
+        "added": "2026-08-06"
+      },
+      "dependencies": [
+        "@base-ui/react",
+        "@liqui-design/glass"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/liqui.json",
+        "utils"
+      ],
       "files": [
-        { "path": "registry/liqui/ui/field.tsx", "type": "registry:ui", "target": "@ui/field.tsx" }
+        {
+          "path": "registry/liqui/ui/field.tsx",
+          "type": "registry:ui",
+          "target": "@ui/field.tsx"
+        }
       ]
     },
     {
@@ -105,11 +161,23 @@
       "type": "registry:ui",
       "title": "Glass Accordion",
       "description": "Collapsible panels where each item is its own resizing glass surface.",
-      "meta": { "added": "2026-08-06" },
-      "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
+      "meta": {
+        "added": "2026-08-06"
+      },
+      "dependencies": [
+        "@base-ui/react",
+        "@liqui-design/glass"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/liqui.json",
+        "utils"
+      ],
       "files": [
-        { "path": "registry/liqui/ui/accordion.tsx", "type": "registry:ui", "target": "@ui/accordion.tsx" }
+        {
+          "path": "registry/liqui/ui/accordion.tsx",
+          "type": "registry:ui",
+          "target": "@ui/accordion.tsx"
+        }
       ]
     },
     {
@@ -117,11 +185,23 @@
       "type": "registry:ui",
       "title": "Glass Alert Dialog",
       "description": "A modal confirmation dialog on the library's largest glass surface.",
-      "meta": { "added": "2026-08-06" },
-      "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
+      "meta": {
+        "added": "2026-08-06"
+      },
+      "dependencies": [
+        "@base-ui/react",
+        "@liqui-design/glass"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/liqui.json",
+        "utils"
+      ],
       "files": [
-        { "path": "registry/liqui/ui/alert-dialog.tsx", "type": "registry:ui", "target": "@ui/alert-dialog.tsx" }
+        {
+          "path": "registry/liqui/ui/alert-dialog.tsx",
+          "type": "registry:ui",
+          "target": "@ui/alert-dialog.tsx"
+        }
       ]
     },
     {
@@ -129,11 +209,23 @@
       "type": "registry:ui",
       "title": "Glass Context Menu",
       "description": "A right-click menu with submenus, checkbox and radio items, on a keep-mounted glass popup.",
-      "meta": { "added": "2026-08-06" },
-      "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
+      "meta": {
+        "added": "2026-08-06"
+      },
+      "dependencies": [
+        "@base-ui/react",
+        "@liqui-design/glass"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/liqui.json",
+        "utils"
+      ],
       "files": [
-        { "path": "registry/liqui/ui/context-menu.tsx", "type": "registry:ui", "target": "@ui/context-menu.tsx" }
+        {
+          "path": "registry/liqui/ui/context-menu.tsx",
+          "type": "registry:ui",
+          "target": "@ui/context-menu.tsx"
+        }
       ]
     },
     {
@@ -141,11 +233,23 @@
       "type": "registry:ui",
       "title": "Glass Dialog",
       "description": "A dismissible modal on glass, with a corner dismiss that stays flat.",
-      "meta": { "added": "2026-08-13" },
-      "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
+      "meta": {
+        "added": "2026-08-13"
+      },
+      "dependencies": [
+        "@base-ui/react",
+        "@liqui-design/glass"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/liqui.json",
+        "utils"
+      ],
       "files": [
-        { "path": "registry/liqui/ui/dialog.tsx", "type": "registry:ui", "target": "@ui/dialog.tsx" }
+        {
+          "path": "registry/liqui/ui/dialog.tsx",
+          "type": "registry:ui",
+          "target": "@ui/dialog.tsx"
+        }
       ]
     },
     {
@@ -153,9 +257,17 @@
       "type": "registry:ui",
       "title": "Glass Popover",
       "description": "A glass panel anchored to a trigger, with a drawn tail.",
-      "meta": { "added": "2026-08-13" },
-      "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
+      "meta": {
+        "added": "2026-08-13"
+      },
+      "dependencies": [
+        "@base-ui/react",
+        "@liqui-design/glass"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/liqui.json",
+        "utils"
+      ],
       "files": [
         {
           "path": "registry/liqui/ui/popover.tsx",
@@ -169,9 +281,17 @@
       "type": "registry:ui",
       "title": "Glass Tooltip",
       "description": "The smallest floating surface, frosted harder so it stays readable.",
-      "meta": { "added": "2026-08-13" },
-      "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
+      "meta": {
+        "added": "2026-08-13"
+      },
+      "dependencies": [
+        "@base-ui/react",
+        "@liqui-design/glass"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/liqui.json",
+        "utils"
+      ],
       "files": [
         {
           "path": "registry/liqui/ui/tooltip.tsx",
@@ -184,24 +304,48 @@
       "name": "switch",
       "type": "registry:ui",
       "title": "Glass Switch",
-      "description": "A switch whose glass track retints with accent, carrying an opaque thumb.",
-      "meta": { "added": "2026-08-10" },
-      "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
+      "description": "A lip-bezel lens: an opaque white pill at rest that swells out of its track and turns to glass under your finger.",
+      "meta": {
+        "added": "2026-08-10"
+      },
+      "dependencies": [
+        "@base-ui/react"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/liqui.json",
+        "utils",
+        "lens"
+      ],
       "files": [
-        { "path": "registry/liqui/ui/switch.tsx", "type": "registry:ui", "target": "@ui/switch.tsx" }
+        {
+          "path": "registry/liqui/ui/switch.tsx",
+          "type": "registry:ui",
+          "target": "@ui/switch.tsx"
+        }
       ]
     },
     {
       "name": "slider",
       "type": "registry:ui",
       "title": "Glass Slider",
-      "description": "A slider whose thumb is the refracting surface, sliding along a flat rail.",
-      "meta": { "added": "2026-08-10" },
-      "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
+      "description": "A convex-lens thumb that magnifies the rail it rides, swelling out of it when grabbed.",
+      "meta": {
+        "added": "2026-08-10"
+      },
+      "dependencies": [
+        "@base-ui/react"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/liqui.json",
+        "utils",
+        "lens"
+      ],
       "files": [
-        { "path": "registry/liqui/ui/slider.tsx", "type": "registry:ui", "target": "@ui/slider.tsx" }
+        {
+          "path": "registry/liqui/ui/slider.tsx",
+          "type": "registry:ui",
+          "target": "@ui/slider.tsx"
+        }
       ]
     },
     {
@@ -209,11 +353,23 @@
       "type": "registry:ui",
       "title": "Glass Select",
       "description": "A select with a glass trigger and a glass popup, kept from overlapping each other.",
-      "meta": { "added": "2026-08-10" },
-      "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
+      "meta": {
+        "added": "2026-08-10"
+      },
+      "dependencies": [
+        "@base-ui/react",
+        "@liqui-design/glass"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/liqui.json",
+        "utils"
+      ],
       "files": [
-        { "path": "registry/liqui/ui/select.tsx", "type": "registry:ui", "target": "@ui/select.tsx" }
+        {
+          "path": "registry/liqui/ui/select.tsx",
+          "type": "registry:ui",
+          "target": "@ui/select.tsx"
+        }
       ]
     },
     {
@@ -221,11 +377,23 @@
       "type": "registry:ui",
       "title": "Glass Tabs",
       "description": "A segmented control whose indicator is the refracting surface, sliding along a flat groove.",
-      "meta": { "added": "2026-08-14" },
-      "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
+      "meta": {
+        "added": "2026-08-14"
+      },
+      "dependencies": [
+        "@base-ui/react",
+        "@liqui-design/glass"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/liqui.json",
+        "utils"
+      ],
       "files": [
-        { "path": "registry/liqui/ui/tabs.tsx", "type": "registry:ui", "target": "@ui/tabs.tsx" }
+        {
+          "path": "registry/liqui/ui/tabs.tsx",
+          "type": "registry:ui",
+          "target": "@ui/tabs.tsx"
+        }
       ]
     },
     {
@@ -233,11 +401,23 @@
       "type": "registry:ui",
       "title": "Glass Toggle",
       "description": "A two-state button whose glass fills with accent while it is on.",
-      "meta": { "added": "2026-08-14" },
-      "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
+      "meta": {
+        "added": "2026-08-14"
+      },
+      "dependencies": [
+        "@base-ui/react",
+        "@liqui-design/glass"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/liqui.json",
+        "utils"
+      ],
       "files": [
-        { "path": "registry/liqui/ui/toggle.tsx", "type": "registry:ui", "target": "@ui/toggle.tsx" }
+        {
+          "path": "registry/liqui/ui/toggle.tsx",
+          "type": "registry:ui",
+          "target": "@ui/toggle.tsx"
+        }
       ]
     },
     {
@@ -245,8 +425,13 @@
       "type": "registry:ui",
       "title": "Glass Toggle Group",
       "description": "One glass strip holding several toggles, which flatten so the strip keeps the lens.",
-      "meta": { "added": "2026-08-14" },
-      "dependencies": ["@base-ui/react", "@liqui-design/glass"],
+      "meta": {
+        "added": "2026-08-14"
+      },
+      "dependencies": [
+        "@base-ui/react",
+        "@liqui-design/glass"
+      ],
       "registryDependencies": [
         "https://liqui.design/r/liqui.json",
         "https://liqui.design/r/toggle.json",
@@ -265,9 +450,17 @@
       "type": "registry:ui",
       "title": "Glass Menu",
       "description": "A dropdown menu with submenus, checkbox and radio items, on a keep-mounted glass popup.",
-      "meta": { "added": "2026-08-20" },
-      "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
+      "meta": {
+        "added": "2026-08-20"
+      },
+      "dependencies": [
+        "@base-ui/react",
+        "@liqui-design/glass"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/liqui.json",
+        "utils"
+      ],
       "files": [
         {
           "path": "registry/liqui/ui/menu.tsx",
@@ -281,9 +474,17 @@
       "type": "registry:ui",
       "title": "Glass Radio Group",
       "description": "A list of options, each its own glass surface, carrying an opaque dot.",
-      "meta": { "added": "2026-08-20" },
-      "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
+      "meta": {
+        "added": "2026-08-20"
+      },
+      "dependencies": [
+        "@base-ui/react",
+        "@liqui-design/glass"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/liqui.json",
+        "utils"
+      ],
       "files": [
         {
           "path": "registry/liqui/ui/radio-group.tsx",
@@ -297,9 +498,17 @@
       "type": "registry:ui",
       "title": "Glass Progress",
       "description": "A progress bar whose track is the refracting surface, filled by a wash of accent.",
-      "meta": { "added": "2026-08-20" },
-      "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
+      "meta": {
+        "added": "2026-08-20"
+      },
+      "dependencies": [
+        "@base-ui/react",
+        "@liqui-design/glass"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/liqui.json",
+        "utils"
+      ],
       "files": [
         {
           "path": "registry/liqui/ui/progress.tsx",
@@ -313,8 +522,13 @@
       "type": "registry:ui",
       "title": "Glass Menubar",
       "description": "One glass strip holding several menus, whose triggers flatten inside it.",
-      "meta": { "added": "2026-08-21" },
-      "dependencies": ["@base-ui/react", "@liqui-design/glass"],
+      "meta": {
+        "added": "2026-08-21"
+      },
+      "dependencies": [
+        "@base-ui/react",
+        "@liqui-design/glass"
+      ],
       "registryDependencies": [
         "https://liqui.design/r/liqui.json",
         "https://liqui.design/r/menu.json",
@@ -333,9 +547,17 @@
       "type": "registry:ui",
       "title": "Glass Number Field",
       "description": "One glass group holding a numeric input and two flattened steppers.",
-      "meta": { "added": "2026-08-21" },
-      "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
+      "meta": {
+        "added": "2026-08-21"
+      },
+      "dependencies": [
+        "@base-ui/react",
+        "@liqui-design/glass"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/liqui.json",
+        "utils"
+      ],
       "files": [
         {
           "path": "registry/liqui/ui/number-field.tsx",
@@ -349,11 +571,23 @@
       "type": "registry:ui",
       "title": "Glass Toast",
       "description": "Notifications laid out in a column, so every surface keeps the page behind it.",
-      "meta": { "added": "2026-08-21" },
-      "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
+      "meta": {
+        "added": "2026-08-21"
+      },
+      "dependencies": [
+        "@base-ui/react",
+        "@liqui-design/glass"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/liqui.json",
+        "utils"
+      ],
       "files": [
-        { "path": "registry/liqui/ui/toast.tsx", "type": "registry:ui", "target": "@ui/toast.tsx" }
+        {
+          "path": "registry/liqui/ui/toast.tsx",
+          "type": "registry:ui",
+          "target": "@ui/toast.tsx"
+        }
       ]
     },
     {
@@ -361,9 +595,16 @@
       "type": "registry:ui",
       "title": "Glass Separator",
       "description": "A hairline groove cut into the surface, lit the way the kernel lights an edge.",
-      "meta": { "added": "2026-08-29" },
-      "dependencies": ["@base-ui/react"],
-      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
+      "meta": {
+        "added": "2026-08-29"
+      },
+      "dependencies": [
+        "@base-ui/react"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/liqui.json",
+        "utils"
+      ],
       "files": [
         {
           "path": "registry/liqui/ui/separator.tsx",
@@ -377,9 +618,17 @@
       "type": "registry:ui",
       "title": "Glass Avatar",
       "description": "A lens with a picture set into it, inset by the width of its own bezel.",
-      "meta": { "added": "2026-08-29" },
-      "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
+      "meta": {
+        "added": "2026-08-29"
+      },
+      "dependencies": [
+        "@base-ui/react",
+        "@liqui-design/glass"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/liqui.json",
+        "utils"
+      ],
       "files": [
         {
           "path": "registry/liqui/ui/avatar.tsx",
@@ -392,10 +641,18 @@
       "name": "collapsible",
       "type": "registry:ui",
       "title": "Glass Collapsible",
-      "description": "A lens on the trigger, frost on the panel \u2014 the box that grows has no map to rebuild.",
-      "meta": { "added": "2026-08-29" },
-      "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
+      "description": "A lens on the trigger, frost on the panel — the box that grows has no map to rebuild.",
+      "meta": {
+        "added": "2026-08-29"
+      },
+      "dependencies": [
+        "@base-ui/react",
+        "@liqui-design/glass"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/liqui.json",
+        "utils"
+      ],
       "files": [
         {
           "path": "registry/liqui/ui/collapsible.tsx",
@@ -409,9 +666,17 @@
       "type": "registry:ui",
       "title": "Glass Meter",
       "description": "A reading on a refracting track, with a wash that changes colour but never slides.",
-      "meta": { "added": "2026-08-29" },
-      "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
+      "meta": {
+        "added": "2026-08-29"
+      },
+      "dependencies": [
+        "@base-ui/react",
+        "@liqui-design/glass"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/liqui.json",
+        "utils"
+      ],
       "files": [
         {
           "path": "registry/liqui/ui/meter.tsx",
@@ -425,9 +690,17 @@
       "type": "registry:ui",
       "title": "Glass Input",
       "description": "A transparent input inside a glass surface, with slots that stay on the same lens.",
-      "meta": { "added": "2026-08-29" },
-      "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
+      "meta": {
+        "added": "2026-08-29"
+      },
+      "dependencies": [
+        "@base-ui/react",
+        "@liqui-design/glass"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/liqui.json",
+        "utils"
+      ],
       "files": [
         {
           "path": "registry/liqui/ui/input.tsx",
@@ -440,10 +713,17 @@
       "name": "fieldset",
       "type": "registry:ui",
       "title": "Glass Fieldset",
-      "description": "A legend and a gap \u2014 the container deliberately isn't a surface.",
-      "meta": { "added": "2026-08-29" },
-      "dependencies": ["@base-ui/react"],
-      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
+      "description": "A legend and a gap — the container deliberately isn't a surface.",
+      "meta": {
+        "added": "2026-08-29"
+      },
+      "dependencies": [
+        "@base-ui/react"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/liqui.json",
+        "utils"
+      ],
       "files": [
         {
           "path": "registry/liqui/ui/fieldset.tsx",
@@ -457,9 +737,16 @@
       "type": "registry:ui",
       "title": "Glass Form",
       "description": "Server errors routed to the field they belong to, and no surface of its own.",
-      "meta": { "added": "2026-08-29" },
-      "dependencies": ["@base-ui/react"],
-      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
+      "meta": {
+        "added": "2026-08-29"
+      },
+      "dependencies": [
+        "@base-ui/react"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/liqui.json",
+        "utils"
+      ],
       "files": [
         {
           "path": "registry/liqui/ui/form.tsx",
@@ -473,9 +760,17 @@
       "type": "registry:ui",
       "title": "Glass Checkbox Group",
       "description": "Shared state for a stack of checkboxes, with a parent box that goes mixed rather than dim.",
-      "meta": { "added": "2026-08-29" },
-      "dependencies": ["@base-ui/react"],
-      "registryDependencies": ["https://liqui.design/r/liqui.json", "https://liqui.design/r/checkbox.json", "utils"],
+      "meta": {
+        "added": "2026-08-29"
+      },
+      "dependencies": [
+        "@base-ui/react"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/liqui.json",
+        "https://liqui.design/r/checkbox.json",
+        "utils"
+      ],
       "files": [
         {
           "path": "registry/liqui/ui/checkbox-group.tsx",
@@ -489,9 +784,17 @@
       "type": "registry:ui",
       "title": "Glass Scroll Area",
       "description": "An overlay scrollbar whose thumb is the smallest lens in the library, and no track behind it.",
-      "meta": { "added": "2026-08-29" },
-      "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
+      "meta": {
+        "added": "2026-08-29"
+      },
+      "dependencies": [
+        "@base-ui/react",
+        "@liqui-design/glass"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/liqui.json",
+        "utils"
+      ],
       "files": [
         {
           "path": "registry/liqui/ui/scroll-area.tsx",
@@ -504,10 +807,19 @@
       "name": "toolbar",
       "type": "registry:ui",
       "title": "Glass Toolbar",
-      "description": "One strip of glass with flat controls on it \u2014 ToggleGroup's rule, generalised.",
-      "meta": { "added": "2026-08-29" },
-      "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["https://liqui.design/r/liqui.json", "https://liqui.design/r/toggle.json", "utils"],
+      "description": "One strip of glass with flat controls on it — ToggleGroup's rule, generalised.",
+      "meta": {
+        "added": "2026-08-29"
+      },
+      "dependencies": [
+        "@base-ui/react",
+        "@liqui-design/glass"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/liqui.json",
+        "https://liqui.design/r/toggle.json",
+        "utils"
+      ],
       "files": [
         {
           "path": "registry/liqui/ui/toolbar.tsx",
@@ -521,9 +833,17 @@
       "type": "registry:ui",
       "title": "Glass Preview Card",
       "description": "Popover's surface with the frost turned up, because this one lands on a sentence.",
-      "meta": { "added": "2026-08-29" },
-      "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
+      "meta": {
+        "added": "2026-08-29"
+      },
+      "dependencies": [
+        "@base-ui/react",
+        "@liqui-design/glass"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/liqui.json",
+        "utils"
+      ],
       "files": [
         {
           "path": "registry/liqui/ui/preview-card.tsx",
@@ -537,9 +857,17 @@
       "type": "registry:ui",
       "title": "Glass Navigation Menu",
       "description": "One panel that moves between triggers and snaps to size, because resizing rebuilds the map.",
-      "meta": { "added": "2026-08-29" },
-      "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
+      "meta": {
+        "added": "2026-08-29"
+      },
+      "dependencies": [
+        "@base-ui/react",
+        "@liqui-design/glass"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/liqui.json",
+        "utils"
+      ],
       "files": [
         {
           "path": "registry/liqui/ui/navigation-menu.tsx",
@@ -553,9 +881,17 @@
       "type": "registry:ui",
       "title": "Glass Combobox",
       "description": "A glass field and popup whose height snaps as you filter, because every height is a map.",
-      "meta": { "added": "2026-08-29" },
-      "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
+      "meta": {
+        "added": "2026-08-29"
+      },
+      "dependencies": [
+        "@base-ui/react",
+        "@liqui-design/glass"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/liqui.json",
+        "utils"
+      ],
       "files": [
         {
           "path": "registry/liqui/ui/combobox.tsx",
@@ -569,9 +905,17 @@
       "type": "registry:ui",
       "title": "Glass Autocomplete",
       "description": "Combobox's surfaces on a field whose value is the text you typed.",
-      "meta": { "added": "2026-08-29" },
-      "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
+      "meta": {
+        "added": "2026-08-29"
+      },
+      "dependencies": [
+        "@base-ui/react",
+        "@liqui-design/glass"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/liqui.json",
+        "utils"
+      ],
       "files": [
         {
           "path": "registry/liqui/ui/autocomplete.tsx",
@@ -585,9 +929,17 @@
       "type": "registry:ui",
       "title": "Glass Drawer",
       "description": "The largest surface in the library, dragged on one cached map.",
-      "meta": { "added": "2026-08-29" },
-      "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
+      "meta": {
+        "added": "2026-08-29"
+      },
+      "dependencies": [
+        "@base-ui/react",
+        "@liqui-design/glass"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/liqui.json",
+        "utils"
+      ],
       "files": [
         {
           "path": "registry/liqui/ui/drawer.tsx",
@@ -601,9 +953,17 @@
       "type": "registry:ui",
       "title": "Glass OTP Field",
       "description": "Six identical surfaces that cost one, because the map cache is keyed on size and optics.",
-      "meta": { "added": "2026-08-29" },
-      "dependencies": ["@base-ui/react", "@liqui-design/glass"],
-      "registryDependencies": ["https://liqui.design/r/liqui.json", "utils"],
+      "meta": {
+        "added": "2026-08-29"
+      },
+      "dependencies": [
+        "@base-ui/react",
+        "@liqui-design/glass"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/liqui.json",
+        "utils"
+      ],
       "files": [
         {
           "path": "registry/liqui/ui/otp-field.tsx",
@@ -617,17 +977,29 @@
       "type": "registry:example",
       "title": "Button",
       "description": "A single glass button.",
-      "registryDependencies": ["https://liqui.design/r/button.json"],
-      "files": [{ "path": "registry/liqui/examples/button-demo.tsx", "type": "registry:example" }]
+      "registryDependencies": [
+        "https://liqui.design/r/button.json"
+      ],
+      "files": [
+        {
+          "path": "registry/liqui/examples/button-demo.tsx",
+          "type": "registry:example"
+        }
+      ]
     },
     {
       "name": "button-variants",
       "type": "registry:example",
       "title": "Variants",
       "description": "Variants retint the glass instead of painting over it.",
-      "registryDependencies": ["https://liqui.design/r/button.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/button.json"
+      ],
       "files": [
-        { "path": "registry/liqui/examples/button-variants.tsx", "type": "registry:example" }
+        {
+          "path": "registry/liqui/examples/button-variants.tsx",
+          "type": "registry:example"
+        }
       ]
     },
     {
@@ -635,9 +1007,14 @@
       "type": "registry:example",
       "title": "Tuning the glass",
       "description": "The glass prop reaches the surface underneath the button.",
-      "registryDependencies": ["https://liqui.design/r/button.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/button.json"
+      ],
       "files": [
-        { "path": "registry/liqui/examples/button-glass-dial.tsx", "type": "registry:example" }
+        {
+          "path": "registry/liqui/examples/button-glass-dial.tsx",
+          "type": "registry:example"
+        }
       ]
     },
     {
@@ -645,9 +1022,14 @@
       "type": "registry:example",
       "title": "Disabled",
       "description": "Disabled buttons drop the hover wash and dim the whole surface.",
-      "registryDependencies": ["https://liqui.design/r/button.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/button.json"
+      ],
       "files": [
-        { "path": "registry/liqui/examples/button-disabled.tsx", "type": "registry:example" }
+        {
+          "path": "registry/liqui/examples/button-disabled.tsx",
+          "type": "registry:example"
+        }
       ]
     },
     {
@@ -655,25 +1037,44 @@
       "type": "registry:example",
       "title": "Checkbox",
       "description": "Checked, unchecked, indeterminate and disabled.",
-      "registryDependencies": ["https://liqui.design/r/checkbox.json"],
-      "files": [{ "path": "registry/liqui/examples/checkbox-demo.tsx", "type": "registry:example" }]
+      "registryDependencies": [
+        "https://liqui.design/r/checkbox.json"
+      ],
+      "files": [
+        {
+          "path": "registry/liqui/examples/checkbox-demo.tsx",
+          "type": "registry:example"
+        }
+      ]
     },
     {
       "name": "field-demo",
       "type": "registry:example",
       "title": "Field",
       "description": "Label, control and description.",
-      "registryDependencies": ["https://liqui.design/r/field.json"],
-      "files": [{ "path": "registry/liqui/examples/field-demo.tsx", "type": "registry:example" }]
+      "registryDependencies": [
+        "https://liqui.design/r/field.json"
+      ],
+      "files": [
+        {
+          "path": "registry/liqui/examples/field-demo.tsx",
+          "type": "registry:example"
+        }
+      ]
     },
     {
       "name": "field-validation",
       "type": "registry:example",
       "title": "Validation",
       "description": "The invalid ring lives on the surface, not the input.",
-      "registryDependencies": ["https://liqui.design/r/field.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/field.json"
+      ],
       "files": [
-        { "path": "registry/liqui/examples/field-validation.tsx", "type": "registry:example" }
+        {
+          "path": "registry/liqui/examples/field-validation.tsx",
+          "type": "registry:example"
+        }
       ]
     },
     {
@@ -681,9 +1082,14 @@
       "type": "registry:example",
       "title": "Accordion",
       "description": "Each item is its own glass surface, resizing with its panel.",
-      "registryDependencies": ["https://liqui.design/r/accordion.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/accordion.json"
+      ],
       "files": [
-        { "path": "registry/liqui/examples/accordion-demo.tsx", "type": "registry:example" }
+        {
+          "path": "registry/liqui/examples/accordion-demo.tsx",
+          "type": "registry:example"
+        }
       ]
     },
     {
@@ -691,9 +1097,15 @@
       "type": "registry:example",
       "title": "Alert Dialog",
       "description": "A destructive confirmation over a dimmed scrim.",
-      "registryDependencies": ["https://liqui.design/r/alert-dialog.json", "https://liqui.design/r/button.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/alert-dialog.json",
+        "https://liqui.design/r/button.json"
+      ],
       "files": [
-        { "path": "registry/liqui/examples/alert-dialog-demo.tsx", "type": "registry:example" }
+        {
+          "path": "registry/liqui/examples/alert-dialog-demo.tsx",
+          "type": "registry:example"
+        }
       ]
     },
     {
@@ -701,9 +1113,14 @@
       "type": "registry:example",
       "title": "Context Menu",
       "description": "Submenus, checkbox and radio items, shortcuts and a destructive action.",
-      "registryDependencies": ["https://liqui.design/r/context-menu.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/context-menu.json"
+      ],
       "files": [
-        { "path": "registry/liqui/examples/context-menu-demo.tsx", "type": "registry:example" }
+        {
+          "path": "registry/liqui/examples/context-menu-demo.tsx",
+          "type": "registry:example"
+        }
       ]
     },
     {
@@ -711,32 +1128,60 @@
       "type": "registry:example",
       "title": "Switch",
       "description": "A settings list: on, off and disabled.",
-      "registryDependencies": ["https://liqui.design/r/switch.json"],
-      "files": [{ "path": "registry/liqui/examples/switch-demo.tsx", "type": "registry:example" }]
+      "registryDependencies": [
+        "https://liqui.design/r/switch.json"
+      ],
+      "files": [
+        {
+          "path": "registry/liqui/examples/switch-demo.tsx",
+          "type": "registry:example"
+        }
+      ]
     },
     {
       "name": "slider-demo",
       "type": "registry:example",
       "title": "Slider",
       "description": "A glass thumb travelling along a flat rail.",
-      "registryDependencies": ["https://liqui.design/r/slider.json"],
-      "files": [{ "path": "registry/liqui/examples/slider-demo.tsx", "type": "registry:example" }]
+      "registryDependencies": [
+        "https://liqui.design/r/slider.json"
+      ],
+      "files": [
+        {
+          "path": "registry/liqui/examples/slider-demo.tsx",
+          "type": "registry:example"
+        }
+      ]
     },
     {
       "name": "slider-range",
       "type": "registry:example",
       "title": "Range",
       "description": "Two thumbs on one rail, sharing a single cached map.",
-      "registryDependencies": ["https://liqui.design/r/slider.json"],
-      "files": [{ "path": "registry/liqui/examples/slider-range.tsx", "type": "registry:example" }]
+      "registryDependencies": [
+        "https://liqui.design/r/slider.json"
+      ],
+      "files": [
+        {
+          "path": "registry/liqui/examples/slider-range.tsx",
+          "type": "registry:example"
+        }
+      ]
     },
     {
       "name": "select-demo",
       "type": "registry:example",
       "title": "Select",
       "description": "Grouped options on a glass popup below the trigger.",
-      "registryDependencies": ["https://liqui.design/r/select.json"],
-      "files": [{ "path": "registry/liqui/examples/select-demo.tsx", "type": "registry:example" }]
+      "registryDependencies": [
+        "https://liqui.design/r/select.json"
+      ],
+      "files": [
+        {
+          "path": "registry/liqui/examples/select-demo.tsx",
+          "type": "registry:example"
+        }
+      ]
     },
     {
       "name": "dialog-demo",
@@ -747,7 +1192,12 @@
         "https://liqui.design/r/dialog.json",
         "https://liqui.design/r/button.json"
       ],
-      "files": [{ "path": "registry/liqui/examples/dialog-demo.tsx", "type": "registry:example" }]
+      "files": [
+        {
+          "path": "registry/liqui/examples/dialog-demo.tsx",
+          "type": "registry:example"
+        }
+      ]
     },
     {
       "name": "popover-demo",
@@ -759,7 +1209,12 @@
         "https://liqui.design/r/button.json",
         "https://liqui.design/r/switch.json"
       ],
-      "files": [{ "path": "registry/liqui/examples/popover-demo.tsx", "type": "registry:example" }]
+      "files": [
+        {
+          "path": "registry/liqui/examples/popover-demo.tsx",
+          "type": "registry:example"
+        }
+      ]
     },
     {
       "name": "tooltip-demo",
@@ -770,7 +1225,12 @@
         "https://liqui.design/r/tooltip.json",
         "https://liqui.design/r/button.json"
       ],
-      "files": [{ "path": "registry/liqui/examples/tooltip-demo.tsx", "type": "registry:example" }]
+      "files": [
+        {
+          "path": "registry/liqui/examples/tooltip-demo.tsx",
+          "type": "registry:example"
+        }
+      ]
     },
     {
       "name": "tooltip-sides",
@@ -781,31 +1241,57 @@
         "https://liqui.design/r/tooltip.json",
         "https://liqui.design/r/button.json"
       ],
-      "files": [{ "path": "registry/liqui/examples/tooltip-sides.tsx", "type": "registry:example" }]
+      "files": [
+        {
+          "path": "registry/liqui/examples/tooltip-sides.tsx",
+          "type": "registry:example"
+        }
+      ]
     },
     {
       "name": "tabs-demo",
       "type": "registry:example",
       "title": "Tabs",
       "description": "A glass pill travelling along a flat groove.",
-      "registryDependencies": ["https://liqui.design/r/tabs.json"],
-      "files": [{ "path": "registry/liqui/examples/tabs-demo.tsx", "type": "registry:example" }]
+      "registryDependencies": [
+        "https://liqui.design/r/tabs.json"
+      ],
+      "files": [
+        {
+          "path": "registry/liqui/examples/tabs-demo.tsx",
+          "type": "registry:example"
+        }
+      ]
     },
     {
       "name": "tabs-vertical",
       "type": "registry:example",
       "title": "Vertical",
       "description": "The same indicator, travelling down instead of across.",
-      "registryDependencies": ["https://liqui.design/r/tabs.json"],
-      "files": [{ "path": "registry/liqui/examples/tabs-vertical.tsx", "type": "registry:example" }]
+      "registryDependencies": [
+        "https://liqui.design/r/tabs.json"
+      ],
+      "files": [
+        {
+          "path": "registry/liqui/examples/tabs-vertical.tsx",
+          "type": "registry:example"
+        }
+      ]
     },
     {
       "name": "toggle-demo",
       "type": "registry:example",
       "title": "Toggle",
       "description": "Three independent surfaces: on, off and disabled.",
-      "registryDependencies": ["https://liqui.design/r/toggle.json"],
-      "files": [{ "path": "registry/liqui/examples/toggle-demo.tsx", "type": "registry:example" }]
+      "registryDependencies": [
+        "https://liqui.design/r/toggle.json"
+      ],
+      "files": [
+        {
+          "path": "registry/liqui/examples/toggle-demo.tsx",
+          "type": "registry:example"
+        }
+      ]
     },
     {
       "name": "toggle-group-demo",
@@ -817,7 +1303,10 @@
         "https://liqui.design/r/toggle.json"
       ],
       "files": [
-        { "path": "registry/liqui/examples/toggle-group-demo.tsx", "type": "registry:example" }
+        {
+          "path": "registry/liqui/examples/toggle-group-demo.tsx",
+          "type": "registry:example"
+        }
       ]
     },
     {
@@ -830,7 +1319,10 @@
         "https://liqui.design/r/toggle.json"
       ],
       "files": [
-        { "path": "registry/liqui/examples/toggle-group-multiple.tsx", "type": "registry:example" }
+        {
+          "path": "registry/liqui/examples/toggle-group-multiple.tsx",
+          "type": "registry:example"
+        }
       ]
     },
     {
@@ -838,7 +1330,10 @@
       "type": "registry:example",
       "title": "Menu",
       "description": "A glass trigger and a glass popup that never overlap, with a submenu inside.",
-      "registryDependencies": ["https://liqui.design/r/menu.json", "https://liqui.design/r/button.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/menu.json",
+        "https://liqui.design/r/button.json"
+      ],
       "files": [
         {
           "path": "registry/liqui/examples/menu-demo.tsx",
@@ -851,7 +1346,9 @@
       "type": "registry:example",
       "title": "Radio Group",
       "description": "One lens per option, and a disabled one that keeps its rim.",
-      "registryDependencies": ["https://liqui.design/r/radio-group.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/radio-group.json"
+      ],
       "files": [
         {
           "path": "registry/liqui/examples/radio-group-demo.tsx",
@@ -864,7 +1361,9 @@
       "type": "registry:example",
       "title": "Progress",
       "description": "Three bars at different fills, refracting along their whole length.",
-      "registryDependencies": ["https://liqui.design/r/progress.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/progress.json"
+      ],
       "files": [
         {
           "path": "registry/liqui/examples/progress-demo.tsx",
@@ -877,7 +1376,9 @@
       "type": "registry:example",
       "title": "Indeterminate",
       "description": "No value to show, so the wash covers the track and breathes instead.",
-      "registryDependencies": ["https://liqui.design/r/progress.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/progress.json"
+      ],
       "files": [
         {
           "path": "registry/liqui/examples/progress-indeterminate.tsx",
@@ -894,16 +1395,26 @@
         "https://liqui.design/r/menubar.json",
         "https://liqui.design/r/menu.json"
       ],
-      "files": [{ "path": "registry/liqui/examples/menubar-demo.tsx", "type": "registry:example" }]
+      "files": [
+        {
+          "path": "registry/liqui/examples/menubar-demo.tsx",
+          "type": "registry:example"
+        }
+      ]
     },
     {
       "name": "number-field-demo",
       "type": "registry:example",
       "title": "Number Field",
       "description": "A scrubbable label over a glass group with two flat steppers.",
-      "registryDependencies": ["https://liqui.design/r/number-field.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/number-field.json"
+      ],
       "files": [
-        { "path": "registry/liqui/examples/number-field-demo.tsx", "type": "registry:example" }
+        {
+          "path": "registry/liqui/examples/number-field-demo.tsx",
+          "type": "registry:example"
+        }
       ]
     },
     {
@@ -911,9 +1422,14 @@
       "type": "registry:example",
       "title": "Formatting",
       "description": "The same field as a percentage, formatted through Intl.NumberFormat.",
-      "registryDependencies": ["https://liqui.design/r/number-field.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/number-field.json"
+      ],
       "files": [
-        { "path": "registry/liqui/examples/number-field-format.tsx", "type": "registry:example" }
+        {
+          "path": "registry/liqui/examples/number-field-format.tsx",
+          "type": "registry:example"
+        }
       ]
     },
     {
@@ -925,15 +1441,24 @@
         "https://liqui.design/r/toast.json",
         "https://liqui.design/r/button.json"
       ],
-      "files": [{ "path": "registry/liqui/examples/toast-demo.tsx", "type": "registry:example" }]
+      "files": [
+        {
+          "path": "registry/liqui/examples/toast-demo.tsx",
+          "type": "registry:example"
+        }
+      ]
     },
     {
       "name": "separator-demo",
       "type": "registry:example",
       "title": "Separator",
       "description": "Hairline grooves splitting a glass panel into rows.",
-      "dependencies": ["@liqui-design/glass"],
-      "registryDependencies": ["https://liqui.design/r/separator.json"],
+      "dependencies": [
+        "@liqui-design/glass"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/separator.json"
+      ],
       "files": [
         {
           "path": "registry/liqui/examples/separator-demo.tsx",
@@ -946,8 +1471,12 @@
       "type": "registry:example",
       "title": "Vertical",
       "description": "The same cut turned upright, with the highlight on the other wall.",
-      "dependencies": ["@liqui-design/glass"],
-      "registryDependencies": ["https://liqui.design/r/separator.json"],
+      "dependencies": [
+        "@liqui-design/glass"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/separator.json"
+      ],
       "files": [
         {
           "path": "registry/liqui/examples/separator-vertical.tsx",
@@ -960,7 +1489,9 @@
       "type": "registry:example",
       "title": "Avatar",
       "description": "A picture that loads, one that fails, and one that was never given.",
-      "registryDependencies": ["https://liqui.design/r/avatar.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/avatar.json"
+      ],
       "files": [
         {
           "path": "registry/liqui/examples/avatar-demo.tsx",
@@ -973,7 +1504,9 @@
       "type": "registry:example",
       "title": "Sizes",
       "description": "One ratio at five diameters, so the smallest disc is still the material.",
-      "registryDependencies": ["https://liqui.design/r/avatar.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/avatar.json"
+      ],
       "files": [
         {
           "path": "registry/liqui/examples/avatar-sizes.tsx",
@@ -986,7 +1519,9 @@
       "type": "registry:example",
       "title": "Collapsible",
       "description": "A refracting trigger over a frosted panel that grows for free.",
-      "registryDependencies": ["https://liqui.design/r/collapsible.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/collapsible.json"
+      ],
       "files": [
         {
           "path": "registry/liqui/examples/collapsible-demo.tsx",
@@ -999,7 +1534,9 @@
       "type": "registry:example",
       "title": "Found by search",
       "description": "hiddenUntilFound, so the browser's own find-in-page opens the section.",
-      "registryDependencies": ["https://liqui.design/r/collapsible.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/collapsible.json"
+      ],
       "files": [
         {
           "path": "registry/liqui/examples/collapsible-search.tsx",
@@ -1012,7 +1549,9 @@
       "type": "registry:example",
       "title": "Meter",
       "description": "Three readings of things that already are, so nothing animates into place.",
-      "registryDependencies": ["https://liqui.design/r/meter.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/meter.json"
+      ],
       "files": [
         {
           "path": "registry/liqui/examples/meter-demo.tsx",
@@ -1025,7 +1564,10 @@
       "type": "registry:example",
       "title": "Thresholds",
       "description": "The fill reads --lq-accent, so a threshold is a token override rather than a prop.",
-      "registryDependencies": ["https://liqui.design/r/meter.json", "https://liqui.design/r/slider.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/meter.json",
+        "https://liqui.design/r/slider.json"
+      ],
       "files": [
         {
           "path": "registry/liqui/examples/meter-thresholds.tsx",
@@ -1038,7 +1580,9 @@
       "type": "registry:example",
       "title": "Input",
       "description": "Three inputs whose every visible pixel belongs to the surface around them.",
-      "registryDependencies": ["https://liqui.design/r/input.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/input.json"
+      ],
       "files": [
         {
           "path": "registry/liqui/examples/input-demo.tsx",
@@ -1051,7 +1595,9 @@
       "type": "registry:example",
       "title": "Slots",
       "description": "A glyph and a unit sharing the input's content layer instead of getting their own.",
-      "registryDependencies": ["https://liqui.design/r/input.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/input.json"
+      ],
       "files": [
         {
           "path": "registry/liqui/examples/input-slots.tsx",
@@ -1064,7 +1610,10 @@
       "type": "registry:example",
       "title": "Fieldset",
       "description": "Three fields under one legend, with no box drawn around them.",
-      "registryDependencies": ["https://liqui.design/r/fieldset.json", "https://liqui.design/r/field.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/fieldset.json",
+        "https://liqui.design/r/field.json"
+      ],
       "files": [
         {
           "path": "registry/liqui/examples/fieldset-demo.tsx",
@@ -1077,7 +1626,11 @@
       "type": "registry:example",
       "title": "Form",
       "description": "A server rejection landing on the field it belongs to, and clearing as you type.",
-      "registryDependencies": ["https://liqui.design/r/form.json", "https://liqui.design/r/field.json", "https://liqui.design/r/button.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/form.json",
+        "https://liqui.design/r/field.json",
+        "https://liqui.design/r/button.json"
+      ],
       "files": [
         {
           "path": "registry/liqui/examples/form-demo.tsx",
@@ -1090,7 +1643,11 @@
       "type": "registry:example",
       "title": "Checkbox Group",
       "description": "Four lenses in a stack, with the page still behind every one of them.",
-      "registryDependencies": ["https://liqui.design/r/checkbox-group.json", "https://liqui.design/r/checkbox.json", "https://liqui.design/r/fieldset.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/checkbox-group.json",
+        "https://liqui.design/r/checkbox.json",
+        "https://liqui.design/r/fieldset.json"
+      ],
       "files": [
         {
           "path": "registry/liqui/examples/checkbox-group-demo.tsx",
@@ -1103,7 +1660,10 @@
       "type": "registry:example",
       "title": "Parent checkbox",
       "description": "The mixed state as a different mark on the same material.",
-      "registryDependencies": ["https://liqui.design/r/checkbox-group.json", "https://liqui.design/r/checkbox.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/checkbox-group.json",
+        "https://liqui.design/r/checkbox.json"
+      ],
       "files": [
         {
           "path": "registry/liqui/examples/checkbox-group-parent.tsx",
@@ -1116,7 +1676,9 @@
       "type": "registry:example",
       "title": "Scroll Area",
       "description": "A refracting thumb over the page, and content that fades where it leaves the box.",
-      "registryDependencies": ["https://liqui.design/r/scroll-area.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/scroll-area.json"
+      ],
       "files": [
         {
           "path": "registry/liqui/examples/scroll-area-demo.tsx",
@@ -1129,8 +1691,12 @@
       "type": "registry:example",
       "title": "Inside a panel",
       "description": "The same thumb with and without its lens, on a surface that leaves it nothing to bend.",
-      "dependencies": ["@liqui-design/glass"],
-      "registryDependencies": ["https://liqui.design/r/scroll-area.json"],
+      "dependencies": [
+        "@liqui-design/glass"
+      ],
+      "registryDependencies": [
+        "https://liqui.design/r/scroll-area.json"
+      ],
       "files": [
         {
           "path": "registry/liqui/examples/scroll-area-on-panel.tsx",
@@ -1143,7 +1709,11 @@
       "type": "registry:example",
       "title": "Toolbar",
       "description": "Eight controls on one lens, including toggles that flatten themselves.",
-      "registryDependencies": ["https://liqui.design/r/toolbar.json", "https://liqui.design/r/toggle.json", "https://liqui.design/r/menu.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/toolbar.json",
+        "https://liqui.design/r/toggle.json",
+        "https://liqui.design/r/menu.json"
+      ],
       "files": [
         {
           "path": "registry/liqui/examples/toolbar-demo.tsx",
@@ -1156,7 +1726,9 @@
       "type": "registry:example",
       "title": "Vertical",
       "description": "The strip turned upright, with the separator's lit wall changing sides.",
-      "registryDependencies": ["https://liqui.design/r/toolbar.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/toolbar.json"
+      ],
       "files": [
         {
           "path": "registry/liqui/examples/toolbar-vertical.tsx",
@@ -1169,7 +1741,9 @@
       "type": "registry:example",
       "title": "Preview Card",
       "description": "A card that opens on a link and has to stay readable over the paragraph under it.",
-      "registryDependencies": ["https://liqui.design/r/preview-card.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/preview-card.json"
+      ],
       "files": [
         {
           "path": "registry/liqui/examples/preview-card-demo.tsx",
@@ -1182,7 +1756,9 @@
       "type": "registry:example",
       "title": "Delay",
       "description": "100ms against the default 600ms, and why the slower one is also the cheaper one.",
-      "registryDependencies": ["https://liqui.design/r/preview-card.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/preview-card.json"
+      ],
       "files": [
         {
           "path": "registry/liqui/examples/preview-card-delay.tsx",
@@ -1195,7 +1771,9 @@
       "type": "registry:example",
       "title": "Navigation Menu",
       "description": "One panel gliding between triggers, snapping to each item's size.",
-      "registryDependencies": ["https://liqui.design/r/navigation-menu.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/navigation-menu.json"
+      ],
       "files": [
         {
           "path": "registry/liqui/examples/navigation-menu-demo.tsx",
@@ -1208,7 +1786,9 @@
       "type": "registry:example",
       "title": "Combobox",
       "description": "A filtered list that snaps between a small set of repeating heights.",
-      "registryDependencies": ["https://liqui.design/r/combobox.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/combobox.json"
+      ],
       "files": [
         {
           "path": "registry/liqui/examples/combobox-demo.tsx",
@@ -1221,7 +1801,9 @@
       "type": "registry:example",
       "title": "Multiple",
       "description": "Flat chips inside the field's lens, because a chip with a bezel would refract the field.",
-      "registryDependencies": ["https://liqui.design/r/combobox.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/combobox.json"
+      ],
       "files": [
         {
           "path": "registry/liqui/examples/combobox-multiple.tsx",
@@ -1234,7 +1816,9 @@
       "type": "registry:example",
       "title": "Autocomplete",
       "description": "Suggestions with no check gutter, because nothing in the list is the current one.",
-      "registryDependencies": ["https://liqui.design/r/autocomplete.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/autocomplete.json"
+      ],
       "files": [
         {
           "path": "registry/liqui/examples/autocomplete-demo.tsx",
@@ -1247,7 +1831,10 @@
       "type": "registry:example",
       "title": "Drawer",
       "description": "A bottom sheet dragged to dismiss, with no filter rebuilt on the way.",
-      "registryDependencies": ["https://liqui.design/r/drawer.json", "https://liqui.design/r/button.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/drawer.json",
+        "https://liqui.design/r/button.json"
+      ],
       "files": [
         {
           "path": "registry/liqui/examples/drawer-demo.tsx",
@@ -1260,7 +1847,10 @@
       "type": "registry:example",
       "title": "From the side",
       "description": "The same sheet against a different edge, on the same cached map.",
-      "registryDependencies": ["https://liqui.design/r/drawer.json", "https://liqui.design/r/button.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/drawer.json",
+        "https://liqui.design/r/button.json"
+      ],
       "files": [
         {
           "path": "registry/liqui/examples/drawer-side.tsx",
@@ -1273,7 +1863,9 @@
       "type": "registry:example",
       "title": "OTP Field",
       "description": "Six slots sharing one displacement map, with filled digits retinting rather than filling.",
-      "registryDependencies": ["https://liqui.design/r/otp-field.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/otp-field.json"
+      ],
       "files": [
         {
           "path": "registry/liqui/examples/otp-field-demo.tsx",
@@ -1286,7 +1878,9 @@
       "type": "registry:example",
       "title": "Grouped",
       "description": "123-456, with the separator cut short so it does not read as an empty slot.",
-      "registryDependencies": ["https://liqui.design/r/otp-field.json"],
+      "registryDependencies": [
+        "https://liqui.design/r/otp-field.json"
+      ],
       "files": [
         {
           "path": "registry/liqui/examples/otp-field-grouped.tsx",
@@ -1299,11 +1893,17 @@
       "type": "registry:block",
       "title": "Media Player",
       "description": "A full-screen player: cover art, transport, library and sound settings, built so that changing track changes what every surface refracts.",
-      "categories": ["template"],
+      "categories": [
+        "template"
+      ],
       "meta": {
         "entry": "registry/liqui/components/media-player/media-player.tsx"
       },
-      "dependencies": ["@base-ui/react", "@liqui-design/glass", "lucide-react"],
+      "dependencies": [
+        "@base-ui/react",
+        "@liqui-design/glass",
+        "lucide-react"
+      ],
       "registryDependencies": [
         "https://liqui.design/r/liqui.json",
         "https://liqui.design/r/button.json",

--- a/apps/www/registry/liqui/components/media-player/transport-bar.tsx
+++ b/apps/www/registry/liqui/components/media-player/transport-bar.tsx
@@ -36,7 +36,6 @@ import { Toggle, ToggleOwnsSurface } from '@/registry/liqui/ui/toggle';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/registry/liqui/ui/tooltip';
 import {
   ON_PANEL,
-  ON_PANEL_KNOB,
   ON_PANEL_TINT,
 } from '@/registry/liqui/components/media-player/on-panel';
 import { formatTime, type Track } from '@/registry/liqui/lib/media-player-data';
@@ -166,7 +165,7 @@ export function TransportBar({
           >
             <SliderControl className="py-1.5">
               <SliderTrack className="h-2">
-                <SliderThumb glass={ON_PANEL} className={cn('size-[18px]', ON_PANEL_KNOB)} />
+                <SliderThumb lens={false} className="size-[18px]" />
               </SliderTrack>
             </SliderControl>
           </Slider>
@@ -205,7 +204,7 @@ export function TransportBar({
           >
             <SliderControl className="py-1.5">
               <SliderTrack className="h-2">
-                <SliderThumb glass={ON_PANEL} className={cn('size-[18px]', ON_PANEL_KNOB)} />
+                <SliderThumb lens={false} className="size-[18px]" />
               </SliderTrack>
             </SliderControl>
           </Slider>
@@ -347,7 +346,7 @@ function SoundPopover({
                 </span>
                 <SliderControl className="py-1">
                   <SliderTrack className="h-2">
-                    <SliderThumb glass={ON_PANEL} className={cn('size-[18px]', ON_PANEL_KNOB)} />
+                    <SliderThumb lens={false} className="size-[18px]" />
                   </SliderTrack>
                 </SliderControl>
                 <span className="w-10 shrink-0 text-right text-[11.5px] tabular-nums text-[var(--lq-text-dim)]">
@@ -383,11 +382,11 @@ function SoundPopover({
         <div className="mt-3 flex flex-col gap-2.5">
           <SwitchLabel>
             Lossless
-            <Switch glass={ON_PANEL} checked={lossless} onCheckedChange={onLosslessChange} />
+            <Switch lens={false} checked={lossless} onCheckedChange={onLosslessChange} />
           </SwitchLabel>
           <SwitchLabel>
             Crossfade
-            <Switch glass={ON_PANEL} checked={crossfade} onCheckedChange={onCrossfadeChange} />
+            <Switch lens={false} checked={crossfade} onCheckedChange={onCrossfadeChange} />
           </SwitchLabel>
         </div>
       </PopoverContent>

--- a/apps/www/registry/liqui/examples/popover-demo.tsx
+++ b/apps/www/registry/liqui/examples/popover-demo.tsx
@@ -35,14 +35,14 @@ export default function PopoverDemo() {
           <SwitchLabel>
             Mentions
             <Switch
-              glass={{ material: 'clear' }}
+              lens={false}
               checked={mentions}
               onCheckedChange={setMentions}
             />
           </SwitchLabel>
           <SwitchLabel>
             Replies
-            <Switch glass={{ material: 'clear' }} checked={replies} onCheckedChange={setReplies} />
+            <Switch lens={false} checked={replies} onCheckedChange={setReplies} />
           </SwitchLabel>
         </div>
         <div className="mt-4 flex justify-end">

--- a/apps/www/registry/liqui/lib/lens.tsx
+++ b/apps/www/registry/liqui/lib/lens.tsx
@@ -1,0 +1,466 @@
+'use client';
+
+import * as React from 'react';
+
+/**
+ * The liqui lens kernel — refraction for a single small control.
+ *
+ * This is not `@liqui-design/glass`, and it is not trying to be. That package
+ * is a *surface*: one shared displacement map and one shared filter, sized for
+ * panels and popovers, tuned so a drawer and a scrollbar thumb can both live
+ * off the same dials. A switch thumb and a slider thumb cannot. They need
+ * their own profile, refraction that moves under your finger, and a specular
+ * that carries colour rather than white — none of which a shared surface
+ * should be made to grow.
+ *
+ * So this file is the part those controls genuinely have in common: solving a
+ * glass profile, painting it into a pair of maps, the filter chain that reads
+ * them, and a spring integrator to drive it. Everything that makes a switch
+ * look like a switch and a slider look like a slider stays in those files —
+ * the surface, the geometry, and every number.
+ *
+ * Chromium only, like all refraction on the web: `backdrop-filter: url(#…)` is
+ * unimplemented elsewhere. Call `supportsRefraction()` and fall back.
+ */
+
+/* -------------------------------------------------------------------------- */
+/* Surfaces                                                                    */
+/* -------------------------------------------------------------------------- */
+
+export interface LensSurface {
+  /** Stable id — keys the profile and map caches. */
+  id: string;
+  /** Height of the glass over normalized depth `t` from the outer edge. */
+  height: (t: number) => number;
+  /**
+   * Thickness of the relief, and of the flat slab of glass beneath it. Only
+   * the ratio matters; the profile is normalized afterwards.
+   *
+   * The slab is not decoration. A level patch of surface with no glass under
+   * it refracts nothing at all, so a profile that flattens anywhere — every
+   * one of these does, in the middle — needs it to keep bending light there.
+   */
+  relief: number;
+  slab: number;
+}
+
+/**
+ * A quarter superellipse rising from 0 to 1: `p = 2` is a circle, `p = 4` the
+ * squircle. The exponent is the tail — it sets how fast the surface flattens
+ * as it leaves the rim, and therefore how far the bend reaches inward.
+ */
+const superellipse = (p: number) => (t: number) => Math.pow(1 - Math.pow(1 - t, p), 1 / p);
+const squircle = superellipse(4);
+const circle = (t: number) => Math.sqrt(1 - (1 - t) * (1 - t));
+const smootherstep = (t: number) => t * t * t * (t * (t * 6 - 15) + 10);
+
+/**
+ * A raised rim around a shallow dish: `squircle(2t)` rises to 1 by the middle
+ * of the band and falls away again — the crest — crossfaded by smootherstep
+ * into the bowl `1 − circle(t)`, lifted so the middle never thins to nothing.
+ *
+ * Its two halves refract in opposite directions, which is the whole point: the
+ * crest pulls the backdrop inward the way any lens edge does, the bowl pushes
+ * it back out, and the middle reads *zoomed out* rather than magnified.
+ */
+export const LIP: LensSurface = {
+  id: 'lip',
+  height: (t) => {
+    const k = smootherstep(t);
+    return squircle(t * 2) * (1 - k) + (1 - circle(t) + 0.1) * k;
+  },
+  // Fitted against the reference's own map: this pair reproduces its measured
+  // curve to 0.26px RMS against a 29px peak. The exponents above turned out to
+  // be exactly right on the first guess; these two were not, and were carrying
+  // most of the error.
+  relief: 2.776,
+  slab: 6.776,
+};
+
+/**
+ * A plain dome, and the one to reach for when the control has something worth
+ * magnifying underneath — a slider's own fill, read through its thumb.
+ *
+ * The exponent is fitted, and it is not either of the obvious choices. A
+ * squircle (p = 4) flattens too abruptly as it leaves the rim: its slope
+ * collapses, the bend dies within a few pixels, and the reference's long
+ * inward reach — still displacing a pixel of backdrop twelve pixels in — is
+ * simply not reachable with it. A circle (p = 2) misses the other end, at the
+ * rim. p = 3.25 with this slab reproduces the measured curve to 0.5px RMS
+ * against a 70px peak; the squircle manages 1.8px.
+ */
+export const CONVEX: LensSurface = {
+  id: 'convex',
+  height: superellipse(3.25),
+  relief: 1.608,
+  slab: 5.945,
+};
+
+/* -------------------------------------------------------------------------- */
+/* Profile                                                                     */
+/* -------------------------------------------------------------------------- */
+
+const PROFILE_SIZE = 128;
+const IOR = 1.5;
+const profileCache = new Map<string, { shift: Float32Array }>();
+
+/**
+ * Lateral shift per unit depth, sampled once along one radius and reused all
+ * the way around the shape — the profile is the same on every side.
+ *
+ * Vector refraction, not an approximation of it: the surface normal comes from
+ * the slope of `height`, the ray is bent through it by Snell's law at n = 1.5,
+ * and then followed until it has crossed the glass.
+ *
+ * Normalized against the *edge*, not the maximum. The surface is vertical
+ * where it meets the rim, so the solution spikes above the edge value for a
+ * sample or two just inside it — a sub-pixel feature at any size a control is
+ * drawn at, and normalizing by it would quietly scale the entire lens down by
+ * whatever that spike happened to reach.
+ */
+function lensProfile(surface: LensSurface): Float32Array {
+  const cached = profileCache.get(surface.id);
+  if (cached) return cached.shift;
+
+  const shift = new Float32Array(PROFILE_SIZE);
+  const a = 1 / IOR;
+  for (let i = 0; i < PROFILE_SIZE; i++) {
+    const t = i / PROFILE_SIZE;
+    const h = 1e-4;
+    const height = surface.height(t);
+    const slope = (surface.height(t + h) - height) / h;
+    const len = Math.hypot(slope, 1);
+    const nx = -slope / len;
+    const ny = -1 / len;
+    const inside = 1 - a * a * (1 - ny * ny);
+    if (inside < 0) continue; // total internal reflection; no ray to follow
+    const k = a * ny + Math.sqrt(inside);
+    const dirX = -k * nx;
+    const dirY = a - k * ny;
+    const depth = height * surface.relief + surface.slab;
+    shift[i] = dirY !== 0 ? dirX * (depth / dirY) : 0;
+  }
+  const edge = Math.abs(shift[0]) || 1;
+  for (let i = 0; i < PROFILE_SIZE; i++) {
+    shift[i] = Math.max(-1, Math.min(1, shift[i] / edge));
+  }
+  profileCache.set(surface.id, { shift });
+  return shift;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Maps                                                                        */
+/* -------------------------------------------------------------------------- */
+
+export interface LensMaps {
+  displacement: string;
+  specular: string;
+}
+
+/** Direction the rim light comes from: upper right, falling off as cos². */
+const LIGHT_ANGLE = (-60 * Math.PI) / 180;
+
+const mapCache = new Map<string, LensMaps>();
+
+export interface LensMapOptions {
+  /** The lens element's own box, in CSS px. */
+  width: number;
+  height: number;
+  /** Corner radius. Equal to `height / 2` for a capsule. */
+  radius: number;
+  /** Width of the sculpted band, in CSS px, measured inward from the edge. */
+  bezel: number;
+  surface: LensSurface;
+  /** Device pixel ratio to render at. Clamp it yourself; 3 is plenty. */
+  dpr: number;
+}
+
+/**
+ * The displacement and specular maps, drawn per pixel onto a canvas and handed
+ * to the filter as PNGs.
+ *
+ * Cached module-wide on geometry, so a page full of the same control pays for
+ * one pair. Rendered at device resolution and drawn back at CSS size, because
+ * the band is only a handful of CSS pixels wide and describing it with a
+ * handful of samples looks like exactly that.
+ *
+ * A canvas rather than an SVG data URI on purpose: `feImage` rasterizes SVG
+ * with a reduced feature set and silently drops the compositing a
+ * gradient-built map would need.
+ */
+export function buildLensMaps(options: LensMapOptions): LensMaps {
+  const { width, height, radius, bezel, surface, dpr } = options;
+  const key = `${surface.id}|${width}x${height}r${radius}b${bezel.toFixed(3)}@${dpr}`;
+  const hit = mapCache.get(key);
+  if (hit) return hit;
+
+  const W = Math.round(width * dpr);
+  const H = Math.round(height * dpr);
+  const R = radius * dpr;
+  const B = bezel * dpr;
+  const innerW = W - R * 2; // straight run between the two caps
+  const innerH = H - R * 2;
+  const shift = lensProfile(surface);
+
+  const disp = new ImageData(W, H);
+  const spec = new ImageData(W, H);
+  // Neutral everywhere first. Only the band gets written, and everything it
+  // does not touch has to read as "do not move this pixel".
+  new Uint32Array(disp.data.buffer).fill(0xff008080); // little-endian RGBA 128,128,0,255
+
+  const rSq = R * R;
+  const outerSq = (R + 1) * (R + 1);
+  const innerSq = (R - B) * (R - B);
+
+  for (let y = 0; y < H; y++) {
+    for (let x = 0; x < W; x++) {
+      // Offset from the nearest corner-circle centre — zero along the straight
+      // edges, which is what turns one radial profile into a rounded-rect band.
+      const lx = x < R ? x - R : x >= W - R ? x - R - innerW : 0;
+      const ly = y < R ? y - R : y >= H - R ? y - R - innerH : 0;
+      const sq = lx * lx + ly * ly;
+      if (sq > outerSq || sq < innerSq) continue;
+
+      const dist = Math.sqrt(sq) || 1e-6;
+      const depth = R - dist;
+      const nx = lx / dist;
+      const ny = ly / dist;
+      // Coverage of the outermost pixel, so the band antialiases into the
+      // border-radius clip rather than stair-stepping against it.
+      const aa = sq < rSq ? 1 : 1 - (dist - R);
+
+      const i = (y * W + x) * 4;
+      const mag = shift[Math.min(((depth / B) * PROFILE_SIZE) | 0, PROFILE_SIZE - 1)] ?? 0;
+      disp.data[i] = 128 - nx * mag * 127 * aa;
+      disp.data[i + 1] = 128 - ny * mag * 127 * aa;
+      disp.data[i + 2] = 0;
+      disp.data[i + 3] = 255;
+
+      // The rim light: one axis of light, cos² around the outward normal, laid
+      // on a hairline just inside the edge — not a broad arc over the band.
+      //
+      // Modelling it as a lit surface instead is the obvious move and it is
+      // wrong. A flat patch of glass faces the viewer, and a viewer-facing
+      // normal still scores well against a light tilted toward the camera, so
+      // the whole middle of the control picks up a fifth of full highlight.
+      // This is also the mask for the saturation pass, so that arrives as a
+      // vivid film over the entire lens.
+      const theta = Math.atan2(ny, nx);
+      const lit = Math.cos(theta - LIGHT_ANGLE) ** 2;
+      const across = Math.abs(depth / dpr - 0.5);
+      const rim = across >= 1 ? 0 : Math.cos((Math.PI / 2) * across);
+      const value = lit * rim * aa;
+      // Colour tracks √intensity while alpha tracks intensity, so a weak part
+      // of the rim reads as dimmer light rather than as thinner white.
+      spec.data[i] = spec.data[i + 1] = spec.data[i + 2] = Math.sqrt(value) * 255;
+      spec.data[i + 3] = value * 255;
+    }
+  }
+
+  const maps = { displacement: toPng(disp), specular: toPng(spec) };
+  mapCache.set(key, maps);
+  return maps;
+}
+
+function toPng(image: ImageData): string {
+  const canvas = document.createElement('canvas');
+  canvas.width = image.width;
+  canvas.height = image.height;
+  canvas.getContext('2d')!.putImageData(image, 0, 0);
+  return canvas.toDataURL();
+}
+
+/* -------------------------------------------------------------------------- */
+/* Filter                                                                      */
+/* -------------------------------------------------------------------------- */
+
+export interface LensFilterProps {
+  id: string;
+  maps: LensMaps;
+  /** The lens element's box, in CSS px — where the maps are laid down. */
+  width: number;
+  height: number;
+  /** `feDisplacementMap` scale for the first paint. Animate it via `scaleRef`. */
+  scale: number;
+  blur: number;
+  specularOpacity: number;
+  specularSaturation: number;
+  scaleRef?: React.Ref<SVGFEDisplacementMapElement>;
+}
+
+/**
+ * The chain, in order: soften the backdrop a hair so the displacement has no
+ * aliasing to amplify; bend it through the map; take a saturated copy of the
+ * bend and keep only what the rim mask covers; blend that coloured rim over
+ * the plain refraction; lay faded white light on top.
+ *
+ * The saturated copy is why the specular is composited here rather than
+ * stacked as a DOM layer. A white rim reads as plastic. A rim that is the
+ * backdrop's own colour pushed until it sings reads as a wet edge.
+ *
+ * The filter deliberately declares no region. The default is the bounding box
+ * plus 10%, and the optics need it: a profile with a concave stretch samples
+ * outward, past the element's own edge, and a region pinned to the element
+ * would have Chromium clamp those samples into a smeared ring.
+ */
+export function LensFilter({
+  id,
+  maps,
+  width,
+  height,
+  scale,
+  blur,
+  specularOpacity,
+  specularSaturation,
+  scaleRef,
+}: LensFilterProps) {
+  return (
+    <svg aria-hidden className="pointer-events-none absolute size-0" focusable="false">
+      <defs>
+        <filter id={id} colorInterpolationFilters="sRGB">
+          <feGaussianBlur in="SourceGraphic" stdDeviation={blur} result="softened" />
+          <feImage href={maps.displacement} x={0} y={0} width={width} height={height} result="map" />
+          <feDisplacementMap
+            ref={scaleRef}
+            in="softened"
+            in2="map"
+            scale={scale}
+            xChannelSelector="R"
+            yChannelSelector="G"
+            result="bent"
+          />
+          <feColorMatrix in="bent" type="saturate" values={`${specularSaturation}`} result="vivid" />
+          <feImage href={maps.specular} x={0} y={0} width={width} height={height} result="rim" />
+          <feComposite in="vivid" in2="rim" operator="in" result="colouredRim" />
+          <feComponentTransfer in="rim" result="whiteRim">
+            <feFuncA type="linear" slope={specularOpacity} />
+          </feComponentTransfer>
+          <feBlend in="colouredRim" in2="bent" result="withColour" />
+          <feBlend in="whiteRim" in2="withColour" />
+        </filter>
+      </defs>
+    </svg>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Springs                                                                     */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * A spring, integrated per frame and written straight to the DOM.
+ *
+ * CSS cannot do this job. A press spring drives an SVG attribute
+ * (`feDisplacementMap scale`) that CSS cannot animate at all, a travel spring
+ * has to be interruptible mid-flight by a drag, and going through React would
+ * re-render the control sixty times a second to move one element.
+ */
+export interface Spring {
+  value: number;
+  velocity: number;
+  target: number;
+  stiffness: number;
+  damping: number;
+  /**
+   * Skip integration and never report settled — the value is being written
+   * from outside, by a finger. A held spring keeps the loop awake so the rest
+   * of the frame still paints.
+   */
+  held?: boolean;
+}
+
+export const spring = (stiffness: number, damping: number, value = 0): Spring => ({
+  value,
+  velocity: 0,
+  target: value,
+  stiffness,
+  damping,
+});
+
+/** Sub-stepped, so a dropped frame cannot blow up a stiff spring. Returns settled. */
+export function advance(s: Spring, dt: number): boolean {
+  const steps = Math.min(Math.ceil(dt / (1 / 240)), 16);
+  const h = dt / steps;
+  for (let i = 0; i < steps; i++) {
+    s.velocity += (s.stiffness * (s.target - s.value) - s.damping * s.velocity) * h;
+    s.value += s.velocity * h;
+  }
+  return Math.abs(s.target - s.value) < 0.0005 && Math.abs(s.velocity) < 0.005;
+}
+
+export const lerp = (a: number, b: number, t: number) => a + (b - a) * t;
+
+export interface SpringLoop {
+  /** Move one spring toward a target, waking the loop if it is asleep. */
+  settle(s: Spring, target: number): void;
+  /** Wake the loop after writing a value directly — mid-drag, say. */
+  wake(): void;
+  /** Put every spring on its target and paint once. */
+  snap(): void;
+  stop(): void;
+  /** When true, `settle` jumps instead of animating. */
+  reduced: boolean;
+}
+
+/**
+ * Drives a set of springs off one `requestAnimationFrame` and stops itself
+ * when they all arrive.
+ *
+ * The loop is shared rather than written per component because the awkward
+ * parts are the same everywhere and are easy to get subtly wrong: every spring
+ * has to be advanced on a frame even once one of them has settled (bail early
+ * and the others freeze mid-flight), a held spring has to keep the loop awake
+ * without being integrated, and `dt` has to be clamped — a backgrounded tab
+ * hands back one enormous delta on return, and an enormous delta is a spring
+ * that explodes.
+ */
+export function createSpringLoop(springs: Spring[], paint: () => void): SpringLoop {
+  let raf = 0;
+  let last = 0;
+
+  const loop: SpringLoop = {
+    reduced: false,
+    settle(s, target) {
+      s.target = target;
+      if (loop.reduced) {
+        s.value = target;
+        s.velocity = 0;
+        paint();
+        return;
+      }
+      loop.wake();
+    },
+    wake() {
+      if (raf) return;
+      last = performance.now();
+      const tick = (now: number) => {
+        const dt = Math.min((now - last) / 1000, 1 / 15);
+        last = now;
+        let settled = true;
+        // `&& settled` on the right, so every spring is advanced every frame.
+        for (const s of springs) settled = (s.held ? false : advance(s, dt)) && settled;
+        paint();
+        raf = settled ? 0 : requestAnimationFrame(tick);
+      };
+      raf = requestAnimationFrame(tick);
+    },
+    snap() {
+      for (const s of springs) {
+        s.value = s.target;
+        s.velocity = 0;
+      }
+      paint();
+    },
+    stop() {
+      cancelAnimationFrame(raf);
+      raf = 0;
+    },
+  };
+  return loop;
+}
+
+export const supportsRefraction = () =>
+  typeof window !== 'undefined' &&
+  CSS.supports('backdrop-filter', 'blur(1px)') &&
+  !/^((?!chrome|chromium|edg|android).)*safari/i.test(navigator.userAgent) &&
+  !/firefox/i.test(navigator.userAgent);

--- a/apps/www/registry/liqui/ui/slider.tsx
+++ b/apps/www/registry/liqui/ui/slider.tsx
@@ -1,34 +1,131 @@
 'use client';
 
+import * as React from 'react';
 import { Slider as BaseSlider } from '@base-ui/react/slider';
-import { LiquiGlass, type LiquiGlassProps } from '@liqui-design/glass';
 
+import {
+  buildLensMaps,
+  createSpringLoop,
+  CONVEX,
+  LensFilter,
+  lerp,
+  spring,
+  supportsRefraction,
+  type LensMaps,
+} from '@/lib/lens';
 import { cn } from '@/lib/utils';
 
 /**
- * liqui Slider — the thumb is the lens, the track is not.
+ * liqui Slider — the thumb is a lens over the rail it rides.
  *
- * This is the mirror image of Switch, and for the same reason: nesting one
- * `backdrop-filter` inside another makes the inner one sample its parent's
- * output instead of the page. Here the moving part is the interesting one, so
- * the track is flattened to a plain translucent rail and the thumb gets to be
- * real glass — it refracts the wallpaper straight through the rail it slides
- * along.
+ * Same construction as [Switch](./switch.tsx): a purpose-built lens rather
+ * than a `LiquiGlass` surface, sharing only the kernel in `@/lib/lens`. The
+ * differences between them are the interesting part, and they are not
+ * cosmetic.
  *
- * Dragging costs nothing extra. The displacement map is keyed on size and
- * optics, and neither changes while the thumb moves, so the whole drag reuses a
- * single cached map and a single registered filter.
+ * A switch thumb has nothing worth magnifying under it, so it uses a lip
+ * bezel: a raised rim around a flat window that reads *zoomed out*. A slider
+ * thumb is sitting on the one thing in the control you actually want to look
+ * at — the rail, and the fill that says where the value is — so it uses a
+ * plain convex dome instead, and magnifies it. Drag one and the rail visibly
+ * fattens as it passes behind the glass.
+ *
+ * The other difference is how hard the edge bends. The band here is a narrow
+ * ring, and inside it the outermost pixels sample from *more than a thumb
+ * height away*. That is what turns the rail's straight edge into the curled
+ * lip of a real piece of thick glass instead of a soft smear.
  */
 
-const THUMB_GLASS = {
-  radius: 13,
-  blur: 1,
-  refraction: 34,
-  bezel: 9,
-} satisfies Partial<LiquiGlassProps>;
+/* -------------------------------------------------------------------------- */
+/* Geometry                                                                    */
+/* -------------------------------------------------------------------------- */
 
-export function Slider({ className, ...props }: BaseSlider.Root.Props) {
-  return <BaseSlider.Root {...props} className={cn('flex w-full flex-col gap-1', className)} />;
+/**
+ * Rail height. **The only number here you should change** — everything below
+ * is a ratio off it, measured from the reference this component reproduces,
+ * where a 330×14 rail carries a 90×60 capsule drawn at 0.6.
+ *
+ * The thumb is deliberately enormous next to the rail: four times its height
+ * even at rest. A lens the size of the thing it sits on has nothing to show.
+ */
+const RAIL_H = 14;
+const K = RAIL_H / 14;
+
+/** The lens's own box. It is drawn at `REST_SCALE`, and only reaches 1 held. */
+const LENS_W = Math.round(90 * K);
+const LENS_H = Math.round(60 * K);
+const LENS_R = LENS_H / 2;
+
+const REST_SCALE = 0.6;
+const PRESS_SCALE = 1;
+
+/**
+ * The thumb's *positioning* box: the lens at rest.
+ *
+ * Base UI insets the thumb from the ends of the track by half its own width,
+ * so this has to be the size the thumb actually looks — not the lens box it
+ * grows into. At value 0 the drawn thumb's left edge then lands exactly on the
+ * rail's, and the lens overflows symmetrically out of this box when pressed.
+ */
+const REST_W = Math.round(LENS_W * REST_SCALE);
+const REST_H = Math.round(LENS_H * REST_SCALE);
+
+/** Published on the root so the parts can size themselves in CSS. */
+const GEOMETRY_VARS = {
+  '--lq-rail-h': `${RAIL_H}px`,
+  '--lq-knob-w': `${REST_W}px`,
+  '--lq-knob-h': `${REST_H}px`,
+  '--lq-knob-pad': `${(REST_H - RAIL_H) / 2}px`,
+} as React.CSSProperties;
+
+/* -------------------------------------------------------------------------- */
+/* Optics                                                                      */
+/* -------------------------------------------------------------------------- */
+
+/** Width of the sculpted band, measured inward from the lens's edge. */
+const BEZEL = 0.417 * LENS_R;
+
+/**
+ * Displacement at the lens's very edge, at ratio 1 — 118% of the lens's own
+ * height. It is meant to look extreme: the outer ring of pixels samples from
+ * beyond the far side of the thumb, and that is the whole difference between
+ * glass with thickness and a blurry circle.
+ */
+const PEAK = 1.178 * LENS_H;
+/** Ratio of `PEAK` the lens runs at, released and held. */
+const REST_RATIO = 0.4;
+const PRESS_RATIO = 0.9;
+
+const BLUR = 0;
+const SPECULAR_OPACITY = 0.4;
+const SPECULAR_SATURATION = 7;
+
+const REST_FILL = 1;
+const PRESS_FILL = 0.1;
+/** Without a lens to uncover, thinning the fill would just delete the thumb. */
+const PRESS_FILL_NO_LENS = 0.72;
+
+/* -------------------------------------------------------------------------- */
+/* Parts                                                                       */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * The root also publishes the geometry as custom properties.
+ *
+ * The parts below could take their sizes from inline styles — and did, until
+ * that silently ate every `className="h-2"` a caller had written, because an
+ * inline style beats a class no matter how specific. Going through variables
+ * keeps `RAIL_H` as the single knob *and* leaves the classes overridable in
+ * the normal way.
+ */
+export function Slider({ className, style, ...props }: BaseSlider.Root.Props) {
+  return (
+    <BaseSlider.Root
+      {...props}
+      style={{ ...GEOMETRY_VARS, ...(style as React.CSSProperties) }}
+      className={cn('flex w-full flex-col gap-1', className)}
+    />
+  );
 }
 
 export function SliderLabel({ className, ...props }: BaseSlider.Label.Props) {
@@ -49,30 +146,41 @@ export function SliderValue({ className, ...props }: BaseSlider.Value.Props) {
   );
 }
 
+/**
+ * The hit area. Its padding is sized so the box is exactly as tall as the
+ * thumb at rest — the thumb grows past it under your finger, and nothing
+ * reserves room for that, because reserving room for a transient would leave a
+ * permanent gap above and below every slider on the page.
+ */
 export function SliderControl({ className, ...props }: BaseSlider.Control.Props) {
   return (
     <BaseSlider.Control
       {...props}
-      // The padding is the hit area. The rail is 12px tall and the thumb 26px,
-      // so without it the control box is shorter than the thing you grab.
-      className={cn('flex w-full touch-none select-none items-center py-2.5', className)}
+      className={cn(
+        'flex w-full touch-none select-none items-center py-[var(--lq-knob-pad)]',
+        className,
+      )}
     />
   );
 }
 
 /**
- * The rail. Deliberately not a LiquiGlass surface — see the note above — so it
- * is drawn the cheap way: a tinted groove with an inset shadow for depth.
- * `Slider.Indicator` fills it from the start edge and inherits its height.
+ * The rail. Deliberately not a glass surface — it is the thumb's backdrop, and
+ * a lens stacked on a lens samples its parent's output instead of the page.
+ *
+ * Flat, and with no inset groove: whatever depth the control has comes from
+ * the thumb, and a rail with its own shadow just competes with the lens
+ * passing over it. The neutral grey is fixed rather than mixed from
+ * `--lq-text` so the rail reads the same on a white sheet and a dark
+ * wallpaper; override `--lq-slider-rail` if your theme wants otherwise.
  */
 export function SliderTrack({ children, className, ...props }: BaseSlider.Track.Props) {
   return (
     <BaseSlider.Track
       {...props}
       className={cn(
-        'h-3 w-full select-none rounded-full',
-        'bg-[color-mix(in_srgb,var(--lq-text)_14%,transparent)]',
-        'shadow-[inset_0_1px_2px_color-mix(in_srgb,var(--lq-text)_16%,transparent),inset_0_0_0_0.5px_var(--lq-rim-lo)]',
+        'h-[var(--lq-rail-h)] w-full select-none rounded-full',
+        'bg-[var(--lq-slider-rail,rgba(137,137,143,0.4))]',
         className,
       )}
     >
@@ -82,26 +190,175 @@ export function SliderTrack({ children, className, ...props }: BaseSlider.Track.
   );
 }
 
-export function SliderThumb({
-  glass,
-  className,
-  ...props
-}: BaseSlider.Thumb.Props & { glass?: Partial<LiquiGlassProps> }) {
+export interface SliderThumbProps extends BaseSlider.Thumb.Props {
+  /**
+   * Set `false` to drop the lens and keep a plain white knob.
+   *
+   * There is one place refraction is not worth its cost: a slider sitting *on*
+   * another glass surface — inside a popover, a drawer, a media-player panel.
+   * `backdrop-filter` samples what is painted behind the element, and behind a
+   * thumb on a frosted panel is the panel's own tint: a flat wash with nothing
+   * in it to bend. Without the lens the thumb takes its size from `className`,
+   * so a panel can ask for a small knob.
+   */
+  lens?: boolean;
+}
+
+export function SliderThumb({ lens = true, className, style, ...props }: SliderThumbProps) {
+  const filterId = `lq-slider-${React.useId().replace(/[^a-zA-Z0-9]/g, '')}`;
+
+  const thumbRef = React.useRef<HTMLDivElement | null>(null);
+  const lensRef = React.useRef<HTMLSpanElement | null>(null);
+  const scaleRef = React.useRef<SVGFEDisplacementMapElement | null>(null);
+  const hasLens = React.useRef(false);
+
+  const [maps, setMaps] = React.useState<LensMaps | null>(null);
+
+  // A plain effect, not a layout effect: at rest the fill is opaque and the
+  // lens is invisible, so there is nothing to flash and no reason to make first
+  // paint wait on two canvas renders and a pair of PNG encodes.
+  React.useEffect(() => {
+    if (!lens || !supportsRefraction()) return;
+    hasLens.current = true;
+    setMaps(
+      buildLensMaps({
+        width: LENS_W,
+        height: LENS_H,
+        radius: LENS_R,
+        bezel: BEZEL,
+        surface: CONVEX,
+        dpr: Math.min(window.devicePixelRatio || 1, 3),
+      }),
+    );
+  }, [lens]);
+
+  /** Barely underdamped (ζ ≈ 0.89), so the grab has some life in it. */
+  const press = React.useRef(spring(2000, 80)).current;
+
+  const paint = React.useCallback(() => {
+    const t = press.value;
+    if (lensRef.current) {
+      lensRef.current.style.scale = `${lerp(REST_SCALE, PRESS_SCALE, t)}`;
+      const floor = hasLens.current ? PRESS_FILL : PRESS_FILL_NO_LENS;
+      lensRef.current.style.backgroundColor = `rgba(255,255,255,${lerp(REST_FILL, floor, t)})`;
+    }
+    if (scaleRef.current) {
+      scaleRef.current.setAttribute('scale', `${PEAK * lerp(REST_RATIO, PRESS_RATIO, t)}`);
+    }
+  }, [press]);
+
+  const paintRef = React.useRef(paint);
+  paintRef.current = paint;
+  const loopRef = React.useRef<ReturnType<typeof createSpringLoop> | null>(null);
+  loopRef.current ??= createSpringLoop([press], () => paintRef.current());
+  const loop = loopRef.current;
+
+  /**
+   * Grabbed-ness comes from Base UI's own `data-dragging`, watched on the
+   * element it is written to.
+   *
+   * It is tempting to bind pointer events here instead, and it would be worse:
+   * Base UI already starts a drag when you press the *rail* — the thumb jumps
+   * to your finger and follows it — and a thumb listening only to its own
+   * pointer events would sit there un-grabbed through the whole gesture.
+   */
+  React.useEffect(() => {
+    const node = thumbRef.current;
+    if (!node) return;
+    const motion = window.matchMedia('(prefers-reduced-motion: reduce)');
+    loop.reduced = motion.matches;
+    const onMotion = () => (loop.reduced = motion.matches);
+    motion.addEventListener('change', onMotion);
+
+    paint();
+    const observer = new MutationObserver(() =>
+      loop.settle(press, node.hasAttribute('data-dragging') ? 1 : 0),
+    );
+    observer.observe(node, { attributes: true, attributeFilter: ['data-dragging'] });
+    return () => {
+      observer.disconnect();
+      motion.removeEventListener('change', onMotion);
+      loop.stop();
+    };
+  }, [loop, paint, press]);
+
+  // Branching on the prop, not on whether the maps have arrived: a thumb that
+  // swapped structure the moment a canvas finished would rebuild Base UI's
+  // input mid-interaction. With a lens the box is fixed — the map is baked for
+  // exactly that size, so it is not a caller's to change — and only the
+  // `backdropFilter` waits.
+  if (!lens) {
+    return (
+      <BaseSlider.Thumb
+        {...props}
+        ref={thumbRef}
+        style={style}
+        className={cn(
+          'select-none rounded-full bg-white',
+          'shadow-[0_3px_14px_rgba(0,0,0,0.1),0_1px_1px_rgba(10,15,40,0.10)]',
+          'outline-none has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-offset-[3px]',
+          'has-[:focus-visible]:outline-[color-mix(in_srgb,var(--lq-accent)_70%,transparent)]',
+          'data-[disabled]:opacity-50',
+          // Through the variables the root publishes, so this still follows
+          // RAIL_H and a caller can still override it with a size class.
+          'h-[var(--lq-knob-h)] w-[var(--lq-knob-w)]',
+          className,
+        )}
+      />
+    );
+  }
+
   return (
     <BaseSlider.Thumb
       {...props}
+      ref={thumbRef}
+      style={{ width: REST_W, height: REST_H, ...style }}
       className={cn(
-        'size-[26px] select-none transition-shadow duration-150',
-        // Cast shadow so the puck reads as lifted off the rail. The focus ring
-        // has to restate it: one `box-shadow` declaration replaces the other.
-        'shadow-[0_2px_6px_rgba(10,15,40,0.26)]',
-        'has-[:focus-visible]:shadow-[0_2px_6px_rgba(10,15,40,0.26),0_0_0_3px_color-mix(in_srgb,var(--lq-accent)_40%,transparent)]',
+        'select-none rounded-full',
+        'outline-none has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-offset-[3px]',
+        'has-[:focus-visible]:outline-[color-mix(in_srgb,var(--lq-accent)_70%,transparent)]',
         'data-[disabled]:opacity-50',
         className,
       )}
-      // Base UI positions the thumb with inline `position/inset/translate`.
-      // LiquiGlass spreads the style it is handed, so those survive the swap.
-      render={<LiquiGlass {...THUMB_GLASS} {...glass} />}
-    />
+    >
+      {maps && (
+        <LensFilter
+          id={filterId}
+          maps={maps}
+          width={LENS_W}
+          height={LENS_H}
+          scale={PEAK * REST_RATIO}
+          blur={BLUR}
+          specularOpacity={SPECULAR_OPACITY}
+          specularSaturation={SPECULAR_SATURATION}
+          scaleRef={scaleRef}
+        />
+      )}
+      {/*
+        The lens, centred on the positioning box above and drawn at 0.6, so it
+        fills it exactly at rest and overflows it evenly when grabbed. Its
+        white fill is the element's own background, which paints *above* the
+        backdrop — opaque and the thumb is a white knob, a tenth and it is a
+        lens with the rail running through it.
+      */}
+      <span
+        ref={lensRef}
+        aria-hidden
+        style={{
+          position: 'absolute',
+          width: LENS_W,
+          height: LENS_H,
+          borderRadius: LENS_R,
+          left: (REST_W - LENS_W) / 2,
+          top: (REST_H - LENS_H) / 2,
+          scale: REST_SCALE,
+          backgroundColor: `rgba(255,255,255,${REST_FILL})`,
+          boxShadow: '0 3px 14px rgba(0,0,0,0.1)',
+          ...(maps
+            ? { backdropFilter: `url(#${filterId})`, WebkitBackdropFilter: `url(#${filterId})` }
+            : null),
+        }}
+      />
+    </BaseSlider.Thumb>
   );
 }

--- a/apps/www/registry/liqui/ui/switch.tsx
+++ b/apps/www/registry/liqui/ui/switch.tsx
@@ -2,63 +2,403 @@
 
 import * as React from 'react';
 import { Switch as BaseSwitch } from '@base-ui/react/switch';
-import { LiquiGlass, type LiquiGlassProps } from '@liqui-design/glass';
 
+import {
+  buildLensMaps,
+  createSpringLoop,
+  LensFilter,
+  LIP,
+  lerp,
+  spring,
+  supportsRefraction,
+  type LensMaps,
+} from '@/lib/lens';
 import { cn } from '@/lib/utils';
 
 /**
- * liqui Switch — the track is the lens, the thumb is not.
+ * liqui Switch — a purpose-built lens, not a glass surface with a switch on it.
  *
- * A switch is two stacked round-rects, and only one of them can refract.
- * `backdrop-filter` samples whatever is painted *behind* the element, and for a
- * thumb sitting inside the track that backdrop is the track's own tint rather
- * than the page. A glass thumb on a glass track therefore bends the colour it
- * is lying on and reads as a smudge instead of a lens.
+ * The whole component is one idea: **at rest the thumb is an opaque white
+ * pill, and pressing it turns that pill into glass.** Three things happen at
+ * once and none of them can be a CSS transition:
  *
- * The track wins here: it is the larger surface, and it is the one whose colour
- * carries on/off. Slider resolves the same conflict the other way — there the
- * moving part is the interesting one, so the track is flattened instead.
+ * - the thumb swells 38% and breaks out of the track, top and bottom;
+ * - its white fill drops to a tenth, uncovering the lens underneath;
+ * - the refraction more than doubles, so the lens deepens as it is revealed.
  *
- * Switching on retints the glass through `--lq-tint` rather than swapping in a
- * filled pill, so the bezel and the specular arc survive the transition. Same
- * trick as Checkbox.
+ * The optics are a lip bezel — convex at the rim, concave across a wide inner
+ * band, flat in the middle. Only the band refracts. The flat middle is the
+ * point: it is a window, and what it frames is the violently bent edge around
+ * it. A lens that distorts everywhere just looks smeared.
+ *
+ * The refraction kernel lives in `@/lib/lens`, shared with Slider. Everything
+ * that makes this a switch — the profile, the geometry, every number below —
+ * lives here.
  */
 
-const TRACK_GLASS = {
-  radius: 15,
-  blur: 1,
-  refraction: 30,
-  bezel: 10,
-} satisfies Partial<LiquiGlassProps>;
+/* -------------------------------------------------------------------------- */
+/* Geometry                                                                    */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Track height. **The only number here you should change** — everything below
+ * is a ratio off it, so the switch stays in proportion at any size, and the
+ * maps regenerate to match.
+ *
+ * The ratios are not invented. They are measured off the reference this
+ * component reproduces, where the track is 160×67 and the thumb is a 146×92
+ * capsule drawn at 0.65. That proportion — a thumb far wider than the track is
+ * tall, riding a track far longer than an iOS switch — is what gives the lens
+ * enough glass to be worth looking through.
+ */
+const TRACK_H = 34;
+const K = TRACK_H / 67;
+
+const TRACK_W = Math.round(160 * K);
+/** The thumb's *layout* box. It is drawn at `REST_SCALE`, never at 1. */
+const THUMB_W = Math.round(146 * K);
+const THUMB_H = Math.round(92 * K);
+const THUMB_R = THUMB_H / 2;
+
+const REST_SCALE = 0.65;
+const PRESS_SCALE = 0.9;
+
+/** Straight run of the track, less the straight run of the drawn thumb. */
+const TRAVEL = TRACK_W - TRACK_H - (THUMB_W - THUMB_H) * REST_SCALE;
+/** Left offset that lands the drawn thumb on an even inset inside the track. */
+const THUMB_LEFT = (TRACK_H - THUMB_H * REST_SCALE) / 2 - (THUMB_W * (1 - REST_SCALE)) / 2;
+
+/* -------------------------------------------------------------------------- */
+/* Optics                                                                      */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Width of the sculpted band, in thumb-local px, measured inward from the edge.
+ *
+ * At 41% of the thumb's radius it leaves the middle 59% flat and untouched —
+ * a genuinely neutral window, not a weak gradient. Widening this does not make
+ * the effect stronger, it makes it muddier.
+ */
+const BEZEL = 0.413 * THUMB_R;
+
+/**
+ * Displacement at the thumb's very edge, in thumb-local px, at ratio 1 — very
+ * nearly a third of the thumb's own height. It reads as a lot because it is:
+ * the outermost ring of pixels samples from a third of the way across the
+ * thumb, which is what makes the track's edge appear to *wrap* around the
+ * glass rather than merely blur past it.
+ */
+const PEAK = 0.3196 * THUMB_H;
+/** Ratio of `PEAK` the lens runs at, released and held. */
+const REST_RATIO = 0.4;
+const PRESS_RATIO = 0.9;
+
+const BLUR = 0.2 * K;
+const SPECULAR_OPACITY = 0.5;
+const SPECULAR_SATURATION = 6;
+
+/* Press response. */
+const REST_FILL = 1;
+const PRESS_FILL = 0.1;
+/** Without a lens to uncover, thinning the fill would just delete the thumb. */
+const PRESS_FILL_NO_LENS = 0.72;
+/** Pointer travel, in px, that turns a tap into a drag. */
+const DRAG_SLOP = 4;
+/** Stiffness of the rubber band once a drag runs past either end. */
+const OVERDRAG = 22;
+
+/* Precomputed, because the paint below runs on every frame of a drag and these
+   two strings never change. The inset pair is a drag tell, not a press tell: it
+   is the thumb reading as something pushed *along* rather than pushed down. */
+const SHADOW = '0 4px 22px rgba(0,0,0,0.1)';
+const SHADOW_DRAGGING =
+  `${SHADOW}, inset ${2 * K}px ${7 * K}px ${24 * K}px rgba(0,0,0,0.09),` +
+  ` inset ${-2 * K}px ${-7 * K}px ${24 * K}px rgba(255,255,255,0.09)`;
+
+/* -------------------------------------------------------------------------- */
+/* Component                                                                   */
+/* -------------------------------------------------------------------------- */
 
 export interface SwitchProps extends BaseSwitch.Root.Props {
-  /** Overrides for the underlying glass track (radius, refraction, bezel…). */
-  glass?: Partial<LiquiGlassProps>;
+  /**
+   * Set `false` to drop the lens and keep the white pill.
+   *
+   * There is one place refraction is not worth its cost: a switch sitting *on*
+   * another glass surface — inside a popover, a drawer, a media-player panel.
+   * `backdrop-filter` samples what is painted behind the element, and behind a
+   * switch on a frosted panel is the panel's own tint: a flat wash with
+   * nothing in it to bend. The filter runs, the maps decode, and the result is
+   * indistinguishable from not having done any of it.
+   */
+  lens?: boolean;
 }
 
-export function Switch({ glass, className, ...props }: SwitchProps) {
+export function Switch({ className, lens = true, onPointerDown, ...props }: SwitchProps) {
+  const filterId = `lq-switch-${React.useId().replace(/[^a-zA-Z0-9]/g, '')}`;
+
+  const rootRef = React.useRef<HTMLSpanElement | null>(null);
+  const thumbRef = React.useRef<HTMLSpanElement | null>(null);
+  const accentRef = React.useRef<HTMLSpanElement | null>(null);
+  const scaleRef = React.useRef<SVGFEDisplacementMapElement | null>(null);
+  const hasLens = React.useRef(false);
+
+  const [maps, setMaps] = React.useState<LensMaps | null>(null);
+
+  // Canvas is client-only and the tier check sniffs the UA, so both have to
+  // happen after hydration or the server and the client disagree about what to
+  // render. A plain effect, not a layout effect: at rest the fill is opaque and
+  // the lens is invisible, so there is nothing to flash and no reason to make
+  // first paint wait on two canvas renders and a pair of PNG encodes.
+  React.useEffect(() => {
+    if (!lens || !supportsRefraction()) return;
+    hasLens.current = true;
+    setMaps(
+      buildLensMaps({
+        width: THUMB_W,
+        height: THUMB_H,
+        radius: THUMB_R,
+        bezel: BEZEL,
+        surface: LIP,
+        dpr: Math.min(window.devicePixelRatio || 1, 3),
+      }),
+    );
+  }, [lens]);
+
+  const engine = React.useRef({
+    /** Thumb position, 0…1. Overdamped (ζ ≈ 1.27): arrives, never overshoots. */
+    pos: spring(1000, 80),
+    /** Press depth, 0…1. Barely underdamped (ζ ≈ 0.89), so it has some life. */
+    press: spring(2000, 80),
+    /**
+     * Track colour. Its own spring because it is not the thumb's position: it
+     * flips the moment a drag crosses the middle and then travels on its own,
+     * rather than fading through a half-tinted track on the way across.
+     */
+    tint: spring(1000, 80),
+    dragging: false,
+    moved: 0,
+    startX: 0,
+    startPos: 0,
+  }).current;
+
+  const paint = React.useCallback(() => {
+    const { pos, press, tint } = engine;
+    const thumb = thumbRef.current;
+    if (thumb) {
+      thumb.style.translate = `${pos.value * TRAVEL}px -50%`;
+      thumb.style.scale = `${lerp(REST_SCALE, PRESS_SCALE, press.value)}`;
+      const floor = hasLens.current ? PRESS_FILL : PRESS_FILL_NO_LENS;
+      thumb.style.backgroundColor = `rgba(255,255,255,${lerp(REST_FILL, floor, press.value)})`;
+      thumb.style.boxShadow = engine.dragging ? SHADOW_DRAGGING : SHADOW;
+    }
+    if (accentRef.current) accentRef.current.style.opacity = `${tint.value}`;
+    if (scaleRef.current) {
+      scaleRef.current.setAttribute(
+        'scale',
+        `${PEAK * lerp(REST_RATIO, PRESS_RATIO, press.value)}`,
+      );
+    }
+  }, [engine]);
+
+  // Indirected through a ref so the loop, which is built once, never holds a
+  // stale `paint`.
+  const paintRef = React.useRef(paint);
+  paintRef.current = paint;
+  const loopRef = React.useRef<ReturnType<typeof createSpringLoop> | null>(null);
+  loopRef.current ??= createSpringLoop([engine.pos, engine.press, engine.tint], () =>
+    paintRef.current(),
+  );
+  const loop = loopRef.current;
+  const settle = loop.settle;
+
+  /**
+   * The checked state is read off the DOM rather than mirrored in React.
+   *
+   * Base UI owns it, and it may be controlled or uncontrolled — a mirror would
+   * have to guess which, and would be wrong for a controlled switch whose
+   * parent declines the change. `data-checked` is the attribute the styles
+   * already key on, so watching it is watching the truth.
+   */
+  React.useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+    const motion = window.matchMedia('(prefers-reduced-motion: reduce)');
+    loop.reduced = motion.matches;
+    const onMotion = () => (loop.reduced = motion.matches);
+    motion.addEventListener('change', onMotion);
+
+    const read = () => (root.hasAttribute('data-checked') ? 1 : 0);
+    // No opening animation: the first frame is wherever the switch already is.
+    engine.pos.value = engine.pos.target = read();
+    engine.tint.value = engine.tint.target = engine.pos.value;
+    paint();
+
+    const observer = new MutationObserver(() => {
+      if (engine.dragging) return;
+      settle(engine.pos, read());
+      settle(engine.tint, read());
+    });
+    observer.observe(root, { attributes: true, attributeFilter: ['data-checked'] });
+    return () => {
+      observer.disconnect();
+      motion.removeEventListener('change', onMotion);
+      loop.stop();
+    };
+  }, [engine, loop, paint, settle]);
+
+  const onPointerMove = React.useCallback(
+    (event: PointerEvent) => {
+      const dx = event.clientX - engine.startX;
+      engine.moved = Math.max(engine.moved, Math.abs(dx));
+      if (engine.moved < DRAG_SLOP) return;
+      engine.dragging = true;
+      engine.pos.held = true;
+      // Follow the finger exactly — a spring between pointer and thumb is the
+      // one place a spring reads as lag rather than life — but let it run past
+      // either end on a rubber band, so the track has a floor and a ceiling you
+      // can feel.
+      const raw = engine.startPos + dx / TRAVEL;
+      const over = raw < 0 ? -raw : raw > 1 ? raw - 1 : 0;
+      engine.pos.value = Math.min(1, Math.max(0, raw)) + Math.sign(raw) * (over / OVERDRAG);
+      engine.pos.velocity = 0;
+      settle(engine.tint, engine.pos.value > 0.5 ? 1 : 0);
+      loop.wake();
+    },
+    [engine, loop, settle],
+  );
+
+  const onPointerUp = React.useCallback(() => {
+    const root = rootRef.current;
+    window.removeEventListener('pointermove', onPointerMove);
+    window.removeEventListener('pointerup', onPointerUp);
+    window.removeEventListener('pointercancel', onPointerUp);
+    settle(engine.press, 0);
+
+    if (!engine.dragging || !root) return;
+    engine.dragging = false;
+    engine.pos.held = false;
+
+    const wants = engine.pos.value > 0.5 ? 1 : 0;
+    const current = root.hasAttribute('data-checked') ? 1 : 0;
+
+    // Snap the animation back to whatever the state *actually* is, before
+    // deciding anything. If the toggle below lands, the observer moves both
+    // springs again; if it never happens — a controlled switch refusing the
+    // change — this is already the truth. Without it a refused drag leaves the
+    // track tinted for a state the switch is not in.
+    settle(engine.pos, current);
+    settle(engine.tint, current);
+
+    /**
+     * A drag and a tap both end in a `click`, and Base UI toggles on click. A
+     * drag that lands on the far side wants exactly that toggle, so it is let
+     * through; a drag that returns to the side it started on wants nothing to
+     * happen, so the click is swallowed on the way up. The state is never
+     * written twice, and a controlled switch still gets to refuse the change.
+     */
+    if (wants === current) {
+      root.addEventListener('click', (e) => { e.preventDefault(); e.stopPropagation(); }, {
+        capture: true,
+        once: true,
+      });
+    }
+  }, [engine, loop, onPointerMove, settle]);
+
   return (
     <BaseSwitch.Root
       {...props}
+      ref={rootRef}
+      onPointerDown={(event) => {
+        onPointerDown?.(event);
+        if (event.defaultPrevented || props.disabled || props.readOnly) return;
+        // Pointer capture is what makes a drag that ends off the control still
+        // count. Without it the release retargets to whatever is under the
+        // cursor, no `click` is dispatched on the switch, and a drag that flung
+        // the thumb across simply never commits.
+        event.currentTarget.setPointerCapture?.(event.pointerId);
+        engine.moved = 0;
+        engine.startX = event.clientX;
+        engine.startPos = engine.pos.value;
+        settle(engine.press, 1);
+        window.addEventListener('pointermove', onPointerMove);
+        window.addEventListener('pointerup', onPointerUp);
+        window.addEventListener('pointercancel', onPointerUp);
+      }}
+      style={{ width: TRACK_W, height: TRACK_H, borderRadius: TRACK_H / 2 }}
       className={cn(
-        'h-[30px] w-[52px] flex-none cursor-default outline-none transition-shadow duration-150',
-        'focus-visible:shadow-[0_0_0_3px_color-mix(in_srgb,var(--lq-accent)_40%,transparent)]',
-        'data-[checked]:[--lq-tint:color-mix(in_srgb,var(--lq-accent)_88%,transparent)] data-[checked]:[--lq-tint-deep:color-mix(in_srgb,var(--lq-accent)_66%,transparent)]',
+        'relative inline-block flex-none cursor-default touch-none select-none align-middle',
+        // No overflow clip and no isolation, on purpose. The thumb swells past
+        // the track under your finger, and its backdrop has to reach the page
+        // rather than stop at this element.
+        'outline-none focus-visible:outline-2 focus-visible:outline-offset-[3px]',
+        'focus-visible:outline-[color-mix(in_srgb,var(--lq-accent)_70%,transparent)]',
         'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',
         className,
       )}
-      render={<LiquiGlass {...TRACK_GLASS} {...glass} contentClassName="size-full p-[2px]" />}
     >
+      {/* The track is a flat fill, not a glass surface: it is the thumb's
+          backdrop, and a lens stacked on a lens samples its parent's output
+          instead of the page. It keeps alpha in both states so there is always
+          something behind the thumb worth bending.
+
+          A fixed mid-grey rather than a mix of `--lq-text`, and deliberately:
+          the off state has to read as *off* on a white settings sheet and on a
+          dark wallpaper alike, and a neutral at 47% is the one value that does
+          both. Override `--lq-switch-off` if your theme wants otherwise. */}
+      <span
+        aria-hidden
+        className="pointer-events-none absolute inset-0 rounded-full bg-[var(--lq-switch-off,rgba(148,148,159,0.47))]"
+      />
+      <span
+        ref={accentRef}
+        aria-hidden
+        style={{ opacity: 0 }}
+        className="pointer-events-none absolute inset-0 rounded-full bg-[color-mix(in_srgb,var(--lq-accent)_93%,transparent)]"
+      />
+
+      {maps && (
+        <LensFilter
+          id={filterId}
+          maps={maps}
+          width={THUMB_W}
+          height={THUMB_H}
+          scale={PEAK * REST_RATIO}
+          blur={BLUR}
+          specularOpacity={SPECULAR_OPACITY}
+          specularSaturation={SPECULAR_SATURATION}
+          scaleRef={scaleRef}
+        />
+      )}
+
+      {/*
+        The thumb is drawn at 0.65 and pressed to 0.9, so its layout box is
+        half again as big as it ever looks. That is not a trick to save a
+        re-layout — it is why the map has the resolution to hold up when the
+        thumb swells, and why the refraction grows with it: `backdrop-filter`
+        is applied in the element's own coordinates and scaled with everything
+        else.
+
+        Its white fill is the element's own background, which sits *above* the
+        backdrop. That single value is the reveal: opaque and the thumb is a
+        white pill, a tenth and it is the lens.
+      */}
       <BaseSwitch.Thumb
-        className={cn(
-          'block size-[26px] rounded-full bg-white',
-          // Opaque, so it needs its own depth cues: a cast shadow and a hairline
-          // edge. The glass layers underneath supply none of this to a child.
-          'shadow-[0_1px_3px_rgba(10,15,40,0.32),0_0_0_0.5px_rgba(10,15,40,0.06)]',
-          'transition-transform duration-200 ease-[cubic-bezier(0.3,1.25,0.4,1)]',
-          // 52 − 2×2 padding − 26 thumb = 22px of travel.
-          'data-[checked]:translate-x-[22px]',
-        )}
+        ref={thumbRef}
+        className="absolute"
+        style={{
+          width: THUMB_W,
+          height: THUMB_H,
+          borderRadius: THUMB_R,
+          left: THUMB_LEFT,
+          top: TRACK_H / 2,
+          translate: '0px -50%',
+          scale: REST_SCALE,
+          backgroundColor: `rgba(255,255,255,${REST_FILL})`,
+          boxShadow: SHADOW,
+          ...(maps
+            ? { backdropFilter: `url(#${filterId})`, WebkitBackdropFilter: `url(#${filterId})` }
+            : null),
+        }}
       />
     </BaseSwitch.Root>
   );


### PR DESCRIPTION
Both controls now carry their own optics instead of being `LiquiGlass` boxes. At
rest each is an opaque white pill; pressing it turns that pill into glass — the
thumb swells past its track, the white fill drops to a tenth, and the refraction
more than doubles, so the lens deepens as it is uncovered.

Reference: the Switch and Slider sections of
https://kube.io/blog/liquid-glass-css-svg/

## Fidelity

The reference ships its displacement and specular maps as PNGs, so the profiles
were read back out of them pixel by pixel and the surface parameters fitted
against the result rather than eyeballed.

| | Profile error vs the reference's own map |
| --- | --- |
| Switch, lip | **0.26px** RMS against a 29px peak |
| Slider, convex | **0.49px** RMS against a 71px peak |

Rendered side by side on the same backdrop at the same pixel size, both land
around **2%** mean absolute channel difference, most of which is background grid
phase.

Two findings worth calling out:

- **The dome's exponent is the tail.** A squircle (p=4) flattens too abruptly as
  it leaves the rim; the long inward reach the slider needs is not available at
  any thickness. p=3.25 is ~4× more accurate than either obvious choice.
- **The filters must declare no region.** The SVG default is the bounding box
  plus 10%, and a concave stretch samples outward past the element's own edge.
  Pin the region and Chromium clamps those samples into a ring.

## Structure

`registry/liqui/lib/lens.tsx` is a new `registry:lib` item — glass profiles, the
map painter, the filter chain and a spring loop — shared by exactly two
components that measured identical. Every number that makes a switch a switch
stays in its own file.

**`packages/glass` is untouched** (`git diff --stat packages/` is empty). This is
deliberately not a change to the shared surface: a `LiquiGlass` box is one cached
map behind one filter, sized so a drawer and a scrollbar thumb can share dials.
These two need a profile of their own, refraction that moves under a finger, and
a specular that carries colour rather than white.

## Behaviour

- Switch is draggable. Pointer capture makes a drag that ends off the control
  still commit; a drag back to the starting side has its click swallowed, so the
  state is never written twice and a controlled switch can still refuse it.
- Slider takes its grabbed-ness from Base UI's `data-dragging`, because Base UI
  starts a drag when you press the *rail* and a thumb watching only its own
  pointer events would sit there un-grabbed through the whole gesture.
- `prefers-reduced-motion` snaps every spring.

## `lens={false}`

Replaces the old `glass` prop. Refraction is not worth its cost for a control
sitting *on* another glass surface, where the backdrop is the panel's own tint —
a flat wash with nothing in it to bend. The media player and the popover demo
take that path, and so do Safari and Firefox.

## Verification

- `pnpm typecheck`, `pnpm build`, `pnpm --filter www test:checks` (22/22) — all green
- Playground builds; its `@/lib/lens` alias added to `vite.config.ts` + `tsconfig.json`
- Interaction probed in a real browser on both: press ramps, drag, rubber-band
  overdrag, drag-back, tap, keyboard — no console errors
- No changeset: `packages/glass` untouched, and `www`/`playground` are ignored

## Notes for review

- **`e2e/visual.spec.ts` baselines are not updated here.** The committed set is
  already stale repo-wide — a clean-tree run on `dev` fails 50/50 with the same
  15px width shift, so this PR neither caused it nor should quietly rewrite 50
  baselines. Worth a separate pass. CI does not run this suite.
- **Sizing is a judgement call.** The proportions are the reference's, which
  makes both controls noticeably larger than before — most visible where the
  meter demo puts a 12px meter next to the slider. One constant per component
  (`TRACK_H`, `RAIL_H`) moves everything if you want them smaller.