### PR TITLE
Promote to production: control sizing

### DIFF
--- a/apps/www/content/docs/components/slider.mdx
+++ b/apps/www/content/docs/components/slider.mdx
@@ -132,22 +132,32 @@ Chromium-only.
 ### Sizing
 
 ```tsx
-const RAIL_H = 14;
+const RAIL_H = 14;   // matches Meter and Progress
+const LENS_H = 45;   // the lens; everything optical is a ratio off it
 ```
 
-The only number to change. The lens box, its radius, the resting size, the
-band and the peak displacement are all ratios off it — and the root publishes
-the layout ones as custom properties (`--lq-rail-h`, `--lq-knob-w`,
-`--lq-knob-h`, `--lq-knob-pad`) rather than inline styles, so the rail and the
-hit area still follow `RAIL_H` while a caller's `className="h-2"` still wins.
+Two knobs, because they are two decisions. The rail belongs to the
+Meter/Progress family and is sized by them — it is the same `h-3.5` they use, so
+a slider read next to a meter looks like its sibling. The lens belongs to the
+optics and is sized by how much glass the effect needs. Tying one to the other
+means a slider that matches its siblings can only do so by carrying a knob half
+again as tall as anything else on the page.
 
-The lens itself is the exception: its box is inline and not overridable,
-because the maps are baked for exactly that size. If you want a smaller knob on
-a panel, that is what `lens={false}` is for.
+Everything else follows: the lens box is `LENS_H` at the reference's 3:2, its
+radius is half of it, the resting knob is 60% of it, and the band and peak
+displacement are ratios of the radius and the height.
 
-The thumb is deliberately enormous next to the rail — four times its height
-even at rest, seven times when grabbed. A lens the size of the thing it sits on
-has nothing to show.
+The root publishes the layout sizes as custom properties (`--lq-rail-h`,
+`--lq-knob-w`, `--lq-knob-h`, `--lq-knob-pad`) rather than inline styles, so the
+rail and the hit area follow the constants while a caller's `className="h-2"`
+still wins. The lens is the exception — its box is inline and not overridable,
+because the maps are baked for exactly that size. For a smaller knob on a panel,
+that is what `lens={false}` is for.
+
+At rest the knob is 41×27, the same size as [Switch](/docs/components/switch)'s.
+Held, it is a 68×45 lens over a 14px rail — still more than three times the
+thing it sits on, which is the point. A lens the size of what it covers has
+nothing to show.
 
 ## Range
 

--- a/apps/www/content/docs/components/switch.mdx
+++ b/apps/www/content/docs/components/switch.mdx
@@ -183,7 +183,7 @@ the press keeps its swell but gives up the reveal.
 ### Sizing
 
 ```tsx
-const TRACK_H = 34;
+const TRACK_H = 30;
 ```
 
 That is the only number to change. Everything else — track width, thumb box,
@@ -192,6 +192,12 @@ regenerate to match.
 
 The ratios are not invented, and they are not iOS's. The track is 2.39× as long
 as it is tall and the thumb is a capsule far wider than the track is tall,
-because that is what gives the lens enough glass to be worth looking through.
+because that is what gives the lens enough glass to be worth looking through —
+which is why 30 buys a 72px track where the old flat switch was 52px wide.
+
+30 puts the resting thumb at 27px: what [Slider](/docs/components/slider)'s knob
+comes out at, and what this component was before it had a lens. The two should
+read as the same size object. Their tracks differ because a switch contains its
+thumb and a rail does not.
 Two colours are exposed: `--lq-switch-off` for the track, `--lq-accent` for the
 checked fill.

--- a/apps/www/registry/liqui/ui/slider.tsx
+++ b/apps/www/registry/liqui/ui/slider.tsx
@@ -41,19 +41,29 @@ import { cn } from '@/lib/utils';
 /* -------------------------------------------------------------------------- */
 
 /**
- * Rail height. **The only number here you should change** — everything below
- * is a ratio off it, measured from the reference this component reproduces,
- * where a 330×14 rail carries a 90×60 capsule drawn at 0.6.
- *
- * The thumb is deliberately enormous next to the rail: four times its height
- * even at rest. A lens the size of the thing it sits on has nothing to show.
+ * Rail height — deliberately the same `h-3.5` that Meter and Progress use.
+ * A slider read next to a meter should look like its sibling, and the rail is
+ * the part that says so.
  */
 const RAIL_H = 14;
-const K = RAIL_H / 14;
 
-/** The lens's own box. It is drawn at `REST_SCALE`, and only reaches 1 held. */
-const LENS_W = Math.round(90 * K);
-const LENS_H = Math.round(60 * K);
+/**
+ * The lens's own box. **This is the size knob**, and it is separate from the
+ * rail on purpose.
+ *
+ * These are two decisions, not one. The rail belongs to the Meter/Progress
+ * family and is sized by them; the lens belongs to the optics and is sized by
+ * how much glass the effect needs. Tying the lens to the rail — which is what
+ * this did first — meant a slider that matched its siblings could only do so by
+ * carrying a knob half again as tall as anything else on the page.
+ *
+ * The 3:2 aspect is the reference's. The lens is drawn at `REST_SCALE` and only
+ * reaches 1 while held, so at rest this is a 41×27 knob and under a finger it
+ * is a 68×45 lens — still three times the rail it sits on, which is the whole
+ * point. A lens the size of the thing it covers has nothing to show.
+ */
+const LENS_H = 45;
+const LENS_W = Math.round(LENS_H * (90 / 60));
 const LENS_R = LENS_H / 2;
 
 const REST_SCALE = 0.6;

--- a/apps/www/registry/liqui/ui/switch.tsx
+++ b/apps/www/registry/liqui/ui/switch.tsx
@@ -49,9 +49,15 @@ import { cn } from '@/lib/utils';
  * component reproduces, where the track is 160×67 and the thumb is a 146×92
  * capsule drawn at 0.65. That proportion — a thumb far wider than the track is
  * tall, riding a track far longer than an iOS switch — is what gives the lens
- * enough glass to be worth looking through.
+ * enough glass to be worth looking through, and it is why 30 here buys a 72px
+ * track rather than the 52px the old flat switch had.
+ *
+ * 30 puts the resting thumb at 27px, which is what Slider's knob comes out at
+ * and what this component was before it had a lens. The two controls should
+ * read as the same size object; the tracks around them differ because a switch
+ * contains its thumb and a rail does not.
  */
-const TRACK_H = 34;
+const TRACK_H = 30;
 const K = TRACK_H / 67;
 
 const TRACK_W = Math.round(160 * K);


### PR DESCRIPTION
Promotes #31 from `dev`.

Switch and Slider had landed at the reference implementation's own proportions,
which are drawn for a demo page with one control on it. Next to anything else
they read as oversized — most visibly on the meter docs page, where a 12px
meter sat above a slider carrying a 54×36 knob.

| | Before | After |
| --- | --- | --- |
| Switch track | 81×34 | **72×30** |
| Switch thumb (rest / held) | 48×30 / 66×42 | **42×27 / 59×37** |
| Slider rail | 14 | **14** (unchanged — same `h-3.5` as Meter and Progress) |
| Slider knob (rest / held) | 54×36 / 90×60 | **41×27 / 68×45** |

Both knobs are now 27px at rest — the same as each other, and the same as these
components were before they had lenses.

Slider also needed a parameterisation change rather than just a number: the lens
was a ratio off `RAIL_H`, folding two separate decisions into one. The rail
belongs to the Meter/Progress family; the lens is sized by how much glass the
effect needs. `LENS_H` is now its own constant.

The optics survive the shrink — the band is a fraction of the radius, so it
scales with everything else and still gets 11–17 device pixels to describe it.

## Release impact: none

`packages/glass` untouched, no changesets. Same as #30: `release.yml` will be a
no-op and this only deploys the site.

## CI

Green on the PR into `dev` (6/6) and again on `dev` after the merge (CI, Checks).