### PR TITLE
Promote to production: lens controls on the home page and in the template

### DIFF
--- a/apps/www/app/(home)/page.tsx
+++ b/apps/www/app/(home)/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { ArrowUpRight } from 'lucide-react';
 
 import { GlassStage } from '@/components/home/glass-stage';
+import { LensControls } from '@/components/home/lens-controls';
 import { gallery } from '@/lib/shared';
 
 export default function HomePage() {
@@ -43,6 +44,21 @@ export default function HomePage() {
         <code className="rounded bg-fd-muted px-1 py-0.5 text-xs">shadcn add</code> installs. Drag
         the panel across a line and watch the line bend.
       </p>
+
+      <section className="mt-16 sm:mt-20">
+        <h2 className="text-xl font-semibold tracking-tight">
+          Two of them aren&apos;t surfaces
+        </h2>
+        <p className="mt-2 max-w-2xl text-fd-muted-foreground">
+          Switch and Slider don&apos;t sit on glass — they carry a lens of their own, and it is
+          hidden until you touch them. At rest each is an opaque white pill. Press and hold: it
+          swells past its track, thins to a tenth, and the backdrop bends through it. Drag the
+          slider and watch the rail fatten where it crosses the knob.
+        </p>
+        <div className="mt-5">
+          <LensControls />
+        </div>
+      </section>
 
       <section className="mt-14 grid gap-6 sm:grid-cols-3">
         <Feature title="You own the code">

--- a/apps/www/components/home/lens-controls.tsx
+++ b/apps/www/components/home/lens-controls.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import * as React from 'react';
+
+import { Backdrop } from '@/components/home/backdrops';
+import {
+  Slider,
+  SliderControl,
+  SliderLabel,
+  SliderThumb,
+  SliderTrack,
+  SliderValue,
+} from '@/registry/liqui/ui/slider';
+import { Switch, SwitchLabel } from '@/registry/liqui/ui/switch';
+
+/**
+ * The second argument, and a different one from the stage above.
+ *
+ * That stage is a glass *surface*: it is glass the whole time, and you drag it
+ * over an edge to see the edge bend. These two are not surfaces. They carry
+ * their own lens and it is hidden until you touch them — at rest each is an
+ * opaque white pill, and pressing one makes it swell past its track, thin to a
+ * tenth, and turn into a lens with the backdrop bending through it. There is
+ * nothing to drag; the interaction is the reveal.
+ *
+ * They sit directly on the backdrop rather than on a panel, and that is not a
+ * layout preference. `backdrop-filter` samples whatever is painted behind an
+ * element, and behind a control on a frosted panel is the panel's own tint — a
+ * flat wash with nothing in it to bend. A lens needs edges underneath, which is
+ * why the grid is the backdrop here and why the components ship a `lens={false}`
+ * escape hatch for the times they end up on glass anyway.
+ */
+export function LensControls() {
+  const [wifi, setWifi] = React.useState(true);
+  const [lowPower, setLowPower] = React.useState(false);
+  const [level, setLevel] = React.useState(58);
+
+  return (
+    <div
+      data-theme="dark"
+      className="relative isolate overflow-hidden rounded-3xl border border-fd-border"
+    >
+      <Backdrop id="grid" />
+
+      {/* Two columns on a wide screen, because one narrow stack centred in a
+          full-bleed stage leaves the grid doing nothing. Side by side, a line
+          runs under both halves and there is always an edge near a control. */}
+      <div className="relative flex min-h-[15rem] flex-col justify-center gap-8 px-6 py-10 sm:px-10 md:min-h-[17rem] md:flex-row md:items-center md:gap-14">
+        <div className="flex min-w-0 flex-1 flex-col gap-5">
+          <SwitchLabel>
+            Wi-Fi
+            <Switch checked={wifi} onCheckedChange={setWifi} />
+          </SwitchLabel>
+          <SwitchLabel>
+            Low Power Mode
+            <Switch checked={lowPower} onCheckedChange={setLowPower} />
+          </SwitchLabel>
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <Slider
+            value={level}
+            onValueChange={(value) => setLevel(Array.isArray(value) ? value[0] : value)}
+          >
+            <div className="flex items-baseline justify-between">
+              <SliderLabel>Brightness</SliderLabel>
+              <SliderValue />
+            </div>
+            <SliderControl>
+              <SliderTrack>
+                <SliderThumb />
+              </SliderTrack>
+            </SliderControl>
+          </Slider>
+        </div>
+      </div>
+
+      <p className="pointer-events-none absolute right-5 bottom-4 text-[11px] tracking-[0.16em] uppercase text-white/45 select-none">
+        press and hold
+      </p>
+    </div>
+  );
+}

--- a/apps/www/registry/liqui/components/media-player/media-player.tsx
+++ b/apps/www/registry/liqui/components/media-player/media-player.tsx
@@ -172,6 +172,10 @@ export default function MediaPlayer() {
                 on ? [...current, track.id] : current.filter((id) => id !== track.id),
               )
             }
+            volume={volume}
+            onVolumeChange={setVolume}
+            lossless={lossless}
+            onLosslessChange={setLossless}
             className="mx-auto w-full max-w-[300px] sm:max-w-[380px] lg:mx-0"
           />
 
@@ -195,15 +199,11 @@ export default function MediaPlayer() {
             onShuffleChange={setShuffle}
             repeat={repeat}
             onRepeatChange={setRepeat}
-            volume={volume}
-            onVolumeChange={setVolume}
             sound={{
               bands,
               onBandChange: (id, value) => setBands((current) => ({ ...current, [id]: value })),
               output,
               onOutputChange: setOutput,
-              lossless,
-              onLosslessChange: setLossless,
               crossfade,
               onCrossfadeChange: setCrossfade,
             }}

--- a/apps/www/registry/liqui/components/media-player/now-playing.tsx
+++ b/apps/www/registry/liqui/components/media-player/now-playing.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import { LiquiGlass, type LiquiGlassProps } from '@liqui-design/glass';
-import { Heart } from 'lucide-react';
+import { Heart, Volume1, Volume2, VolumeX } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
+import { Slider, SliderControl, SliderThumb, SliderTrack } from '@/registry/liqui/ui/slider';
+import { Switch } from '@/registry/liqui/ui/switch';
 import { coverArt, type Track } from '@/registry/liqui/lib/media-player-data';
 
 /**
@@ -15,6 +17,15 @@ import { coverArt, type Track } from '@/registry/liqui/lib/media-player-data';
  * seams in it, and the plate lying across its lower edge is the lens. Watch the
  * two diagonal bands where they cross the plate: they arrive displaced, and
  * they are the only reason you can tell this is a lens and not a blur.
+ *
+ * The volume slider lives here rather than in the transport bar, and that is
+ * the same argument from the other side. Slider's thumb is a lens, and a lens
+ * needs something with edges behind it: on the transport strip its backdrop is
+ * that strip's own frosted tint — a flat wash — and it has to be installed with
+ * `lens={false}`, which is a white knob. Over the artwork it has the two
+ * diagonal bands to bend, and it is the only control on this page that gets to
+ * be what it is. Drag it across a band and the band arrives displaced, and the
+ * rail visibly fattens where it passes behind the glass.
  *
  * The plate is inset rather than overhanging. An earlier version had it hang
  * off the bottom edge, which put half of it over the page — a better seam, and
@@ -36,13 +47,22 @@ export function NowPlaying({
   track,
   favourite,
   onFavouriteChange,
+  volume,
+  onVolumeChange,
+  lossless,
+  onLosslessChange,
   className,
 }: {
   track: Track;
   favourite: boolean;
   onFavouriteChange: (favourite: boolean) => void;
+  volume: number;
+  onVolumeChange: (volume: number) => void;
+  lossless: boolean;
+  onLosslessChange: (lossless: boolean) => void;
   className?: string;
 }) {
+  const VolumeIcon = volume === 0 ? VolumeX : volume < 50 ? Volume1 : Volume2;
   return (
     <div
       className={cn(
@@ -53,6 +73,47 @@ export function NowPlaying({
       )}
       style={coverArt(track.palette)}
     >
+      {/* Up here because this is where the bands are. The quality toggle is the
+          one control on the page with no reason to sit near the transport, and
+          the top of the cover is both empty and the busiest part of the
+          painting — press it and both diagonals bend at once. */}
+      <label className="absolute top-4 right-4 flex cursor-default items-center gap-2 select-none">
+        <span className="text-[11px] tracking-[0.1em] uppercase text-white/75 [text-shadow:0_1px_3px_rgba(0,0,0,0.45)]">
+          Lossless
+        </span>
+        <Switch checked={lossless} onCheckedChange={onLosslessChange} />
+      </label>
+
+      {/* Laid straight on the artwork, with no surface under it. The mute
+          button is flat — it is a button, not a lens, and two lenses side by
+          side would each only be bending the other. */}
+      <div className="absolute inset-x-4 bottom-[86px] flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => onVolumeChange(volume === 0 ? 60 : 0)}
+          aria-label={volume === 0 ? 'Unmute' : 'Mute'}
+          className={cn(
+            'inline-flex shrink-0 cursor-default items-center justify-center rounded-full p-1.5',
+            'border-none bg-transparent text-white/80 outline-none transition-colors duration-150',
+            'hover:bg-white/15 focus-visible:shadow-[inset_0_0_0_2px_var(--lq-accent)]',
+          )}
+        >
+          <VolumeIcon className="size-[15px]" />
+        </button>
+        <Slider
+          value={volume}
+          onValueChange={(value) => onVolumeChange(Array.isArray(value) ? value[0] : value)}
+          aria-label="Volume"
+          className="min-w-0 flex-1"
+        >
+          <SliderControl>
+            <SliderTrack className="h-2.5">
+              <SliderThumb />
+            </SliderTrack>
+          </SliderControl>
+        </Slider>
+      </div>
+
       <LiquiGlass
         {...PLATE_GLASS}
         className="absolute inset-x-3 bottom-3"

--- a/apps/www/registry/liqui/components/media-player/transport-bar.tsx
+++ b/apps/www/registry/liqui/components/media-player/transport-bar.tsx
@@ -11,8 +11,6 @@ import {
   SkipBack,
   SkipForward,
   SlidersHorizontal,
-  Volume2,
-  VolumeX,
 } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
@@ -89,8 +87,6 @@ export function TransportBar({
   onShuffleChange,
   repeat,
   onRepeatChange,
-  volume,
-  onVolumeChange,
   sound,
   className,
 }: {
@@ -105,12 +101,9 @@ export function TransportBar({
   onShuffleChange: (shuffle: boolean) => void;
   repeat: RepeatMode;
   onRepeatChange: (repeat: RepeatMode) => void;
-  volume: number;
-  onVolumeChange: (volume: number) => void;
   sound: SoundSettings;
   className?: string;
 }) {
-  const muted = volume === 0;
 
   return (
     // `ToggleOwnsSurface` is how ToggleGroup flattens its children, and it
@@ -122,7 +115,7 @@ export function TransportBar({
         {...BAR_GLASS}
         className={className}
         // Wraps into three centred rows on a narrow screen — transport, then
-        // modes and volume, then the scrubber — and collapses to one at `sm`.
+        // modes, then the scrubber — and collapses to one at `sm`.
         contentClassName="flex flex-wrap items-center gap-x-4 gap-y-2.5 rounded-[inherit] px-4 py-3 sm:flex-nowrap"
       >
         <div className="flex w-full shrink-0 items-center justify-center gap-1 sm:w-auto sm:justify-start">
@@ -190,25 +183,6 @@ export function TransportBar({
 
           <span className="mx-1.5 h-5 w-px bg-[var(--lq-rim-lo)]" />
 
-          <IconButton
-            label={muted ? 'Unmute' : 'Mute'}
-            onClick={() => onVolumeChange(muted ? 60 : 0)}
-          >
-            {muted ? <VolumeX className="size-[17px]" /> : <Volume2 className="size-[17px]" />}
-          </IconButton>
-          <Slider
-            value={volume}
-            onValueChange={(value) => onVolumeChange(Array.isArray(value) ? value[0] : value)}
-            aria-label="Volume"
-            className="w-[76px] shrink-0"
-          >
-            <SliderControl className="py-1.5">
-              <SliderTrack className="h-2">
-                <SliderThumb lens={false} className="size-[18px]" />
-              </SliderTrack>
-            </SliderControl>
-          </Slider>
-
           <SoundPopover {...sound} />
         </div>
       </LiquiGlass>
@@ -261,8 +235,6 @@ export interface SoundSettings {
   onBandChange: (id: keyof Bands, value: number) => void;
   output: string;
   onOutputChange: (output: string) => void;
-  lossless: boolean;
-  onLosslessChange: (lossless: boolean) => void;
   crossfade: boolean;
   onCrossfadeChange: (crossfade: boolean) => void;
 }
@@ -300,8 +272,6 @@ function SoundPopover({
   onBandChange,
   output,
   onOutputChange,
-  lossless,
-  onLosslessChange,
   crossfade,
   onCrossfadeChange,
 }: SoundSettings) {
@@ -379,11 +349,7 @@ function SoundPopover({
           </SelectContent>
         </Select>
 
-        <div className="mt-3 flex flex-col gap-2.5">
-          <SwitchLabel>
-            Lossless
-            <Switch lens={false} checked={lossless} onCheckedChange={onLosslessChange} />
-          </SwitchLabel>
+        <div className="mt-3">
           <SwitchLabel>
             Crossfade
             <Switch lens={false} checked={crossfade} onCheckedChange={onCrossfadeChange} />


### PR DESCRIPTION
Promotes #33 from `dev`.

Switch and Slider were rebuilt as lenses in #29/#31 and then only ever appeared
in their own docs pages. Neither of the two places a visitor actually lands
showed them — and in the media player they were installed with `lens={false}`,
which is a white knob, so the work was invisible there by construction.

## The constraint drove both placements

`backdrop-filter` samples whatever is painted behind an element, and behind a
control on a frosted panel is that panel's own tint: a flat wash with nothing in
it to bend. A lens has to sit on something painted with edges in it. That rules
out every glass surface on both pages.

**Home** gets a section of its own rather than a slot in the stage above it,
because it is a different argument: the stage is glass the whole time and you
drag it over an edge; these two are opaque until you touch them, and the
interaction is the reveal. They sit straight on the grid backdrop, two columns
wide so a line runs under both halves.

**Media player** — the only painted surface is the cover art, so both controls
went there. Volume comes off the transport strip and lies across the lower third
of the artwork; the quality toggle goes to the top right, the emptiest part of
the cover and the busiest part of the painting. Lossless also stops being
duplicate state buried in the sound popover; Crossfade stays there.

## Verification

- Template renders **1 switch lens + 1 slider lens** (was 0 and 0)
- Both verified pressed in a browser against the artwork's diagonals
- Templates index (live scaled miniature) clean, no console errors
- Green on the PR into `dev` (6/6) and again on `dev` after the merge (CI, Checks)

## Release impact: none

`packages/glass` untouched, no changesets — `release.yml` is a no-op and this
only deploys the site.

## Flagged for review

Moving **Lossless** onto the cover changes the template's information
architecture: a settings item now sits on the main visual. It is there because
the popover is glass and a switch on it can only be a white knob. Reverting is
just moving the JSX back, at the cost of the template having no lensed switch at
all — there is no second honest spot on that page. The larger alternative is a
new Control Center-style template, where controls float on a wallpaper; that is
a new `registry:block` and was not taken on unasked.